### PR TITLE
Regen JS client from updated swagger spec

### DIFF
--- a/sinopia_client/README.md
+++ b/sinopia_client/README.md
@@ -95,19 +95,8 @@ Please follow the [installation](#installation) instruction and execute the foll
 ```javascript
 var SinopiaServer = require('sinopia_server');
 
-var defaultClient = SinopiaServer.ApiClient.instance;
-
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = "YOUR API KEY"
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix['On-Behalf-Of'] = "Token"
-
 var api = new SinopiaServer.DefaultApi()
-
-var groupID = "groupID_example"; // {String} The group who is defining it's own resources or graph within Sinopia. LDP Container to get.
-
-api.getGroup(groupID).then(function(data) {
+api.healthCheck().then(function(data) {
   console.log('API called successfully. Returned data: ' + data);
 }, function(error) {
   console.error(error);
@@ -122,19 +111,33 @@ All URIs are relative to *https://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*SinopiaServer.DefaultApi* | [**getGroup**](docs/DefaultApi.md#getGroup) | **GET** /repository/{groupID} | Query for RDF about a Group.
 *SinopiaServer.DefaultApi* | [**healthCheck**](docs/DefaultApi.md#healthCheck) | **GET** /healthcheck | Health Check
+*SinopiaServer.LDPApi* | [**createGroup**](docs/LDPApi.md#createGroup) | **POST** /repository | Create new Group within the base container.
+*SinopiaServer.LDPApi* | [**createResource**](docs/LDPApi.md#createResource) | **POST** /repository/{groupID} | Create a resource within a Group.
+*SinopiaServer.LDPApi* | [**createUser**](docs/LDPApi.md#createUser) | **POST** /repository/users | Create a user within Sinopia.
+*SinopiaServer.LDPApi* | [**deleteGroup**](docs/LDPApi.md#deleteGroup) | **DELETE** /repository/{groupID} | Delete an Group.
+*SinopiaServer.LDPApi* | [**deleteResource**](docs/LDPApi.md#deleteResource) | **DELETE** /repository/{groupID}/{resourceID} | Delete a Resource.
+*SinopiaServer.LDPApi* | [**deleteUser**](docs/LDPApi.md#deleteUser) | **DELETE** /repository/users/{userID} | Delete a User.
 *SinopiaServer.LDPApi* | [**getBase**](docs/LDPApi.md#getBase) | **GET** /repository | Get metadata for the base container.
-*SinopiaServer.LDPApi* | [**repositoryGroupIDDelete**](docs/LDPApi.md#repositoryGroupIDDelete) | **DELETE** /repository/{groupID} | 
-*SinopiaServer.LDPApi* | [**repositoryGroupIDHead**](docs/LDPApi.md#repositoryGroupIDHead) | **HEAD** /repository/{groupID} | 
-*SinopiaServer.LDPApi* | [**repositoryGroupIDOptions**](docs/LDPApi.md#repositoryGroupIDOptions) | **OPTIONS** /repository/{groupID} | 
-*SinopiaServer.LDPApi* | [**repositoryGroupIDPatch**](docs/LDPApi.md#repositoryGroupIDPatch) | **PATCH** /repository/{groupID} | 
-*SinopiaServer.LDPApi* | [**repositoryGroupIDPost**](docs/LDPApi.md#repositoryGroupIDPost) | **POST** /repository/{groupID} | Create new Group.
-*SinopiaServer.LDPApi* | [**repositoryGroupIDPut**](docs/LDPApi.md#repositoryGroupIDPut) | **PUT** /repository/{groupID} | 
-*SinopiaServer.LDPApi* | [**repositoryHead**](docs/LDPApi.md#repositoryHead) | **HEAD** /repository | Get headers only of base container request.
-*SinopiaServer.LDPApi* | [**repositoryOptions**](docs/LDPApi.md#repositoryOptions) | **OPTIONS** /repository | 
-*SinopiaServer.LDPApi* | [**repositoryPost**](docs/LDPApi.md#repositoryPost) | **POST** /repository | Create new Group within the base container.
-*SinopiaServer.LDPApi* | [**repositoryPut**](docs/LDPApi.md#repositoryPut) | **PUT** /repository | Update metadata on base container.
+*SinopiaServer.LDPApi* | [**getGroup**](docs/LDPApi.md#getGroup) | **GET** /repository/{groupID} | Get metadata (RDF) for a given Group.
+*SinopiaServer.LDPApi* | [**getResource**](docs/LDPApi.md#getResource) | **GET** /repository/{groupID}/{resourceID} | Get metadata (RDF) for a given resource.
+*SinopiaServer.LDPApi* | [**getUser**](docs/LDPApi.md#getUser) | **GET** /repository/users/{userID} | Get metadata (RDF) for a given user.
+*SinopiaServer.LDPApi* | [**getUsers**](docs/LDPApi.md#getUsers) | **GET** /repository/users | Get metadata (RDF) for the Sinopia users container.
+*SinopiaServer.LDPApi* | [**headBase**](docs/LDPApi.md#headBase) | **HEAD** /repository | Get headers only for base container GET request.
+*SinopiaServer.LDPApi* | [**headGroup**](docs/LDPApi.md#headGroup) | **HEAD** /repository/{groupID} | Get headers only for a group GET request.
+*SinopiaServer.LDPApi* | [**headResource**](docs/LDPApi.md#headResource) | **HEAD** /repository/{groupID}/{resourceID} | Get headers only for a resource GET request.
+*SinopiaServer.LDPApi* | [**headUser**](docs/LDPApi.md#headUser) | **HEAD** /repository/users/{userID} | Get headers only for a user GET request.
+*SinopiaServer.LDPApi* | [**headUsers**](docs/LDPApi.md#headUsers) | **HEAD** /repository/users | Get headers only for a Sinopia users&#39; container GET request.
+*SinopiaServer.LDPApi* | [**optionsBase**](docs/LDPApi.md#optionsBase) | **OPTIONS** /repository | HTTP Options for base container.
+*SinopiaServer.LDPApi* | [**optionsGroup**](docs/LDPApi.md#optionsGroup) | **OPTIONS** /repository/{groupID} | HTTP Options for group.
+*SinopiaServer.LDPApi* | [**optionsResource**](docs/LDPApi.md#optionsResource) | **OPTIONS** /repository/{groupID}/{resourceID} | HTTP Options for resource.
+*SinopiaServer.LDPApi* | [**optionsUser**](docs/LDPApi.md#optionsUser) | **OPTIONS** /repository/users/{userID} | HTTP Options for user.
+*SinopiaServer.LDPApi* | [**optionsUsers**](docs/LDPApi.md#optionsUsers) | **OPTIONS** /repository/users | HTTP Options for Sinopia users&#39; container.
+*SinopiaServer.LDPApi* | [**updateBase**](docs/LDPApi.md#updateBase) | **PUT** /repository | Update metadata on base container.
+*SinopiaServer.LDPApi* | [**updateGroup**](docs/LDPApi.md#updateGroup) | **PUT** /repository/{groupID} | Update metadata on a group.
+*SinopiaServer.LDPApi* | [**updateResource**](docs/LDPApi.md#updateResource) | **PUT** /repository/{groupID}/{resourceID} | Update metadata on a resource.
+*SinopiaServer.LDPApi* | [**updateUser**](docs/LDPApi.md#updateUser) | **PUT** /repository/users/{userID} | Update metadata on a user.
+*SinopiaServer.LDPApi* | [**updateUsers**](docs/LDPApi.md#updateUsers) | **PUT** /repository/users | Update metadata on the Sinopia users&#39; container.
 
 
 ## Documentation for Models

--- a/sinopia_client/docs/DefaultApi.md
+++ b/sinopia_client/docs/DefaultApi.md
@@ -4,59 +4,8 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**getGroup**](DefaultApi.md#getGroup) | **GET** /repository/{groupID} | Query for RDF about a Group.
 [**healthCheck**](DefaultApi.md#healthCheck) | **GET** /healthcheck | Health Check
 
-
-<a name="getGroup"></a>
-# **getGroup**
-> LDPContainer getGroup(groupID)
-
-Query for RDF about a Group.
-
-Get the RDF (default, JSON-LD) for a Group.
-
-### Example
-```javascript
-var SinopiaServer = require('sinopia_server');
-var defaultClient = SinopiaServer.ApiClient.instance;
-
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
-
-var apiInstance = new SinopiaServer.DefaultApi();
-
-var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia. LDP Container to get.
-
-apiInstance.getGroup(groupID).then(function(data) {
-  console.log('API called successfully. Returned data: ' + data);
-}, function(error) {
-  console.error(error);
-});
-
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. LDP Container to get. | 
-
-### Return type
-
-[**LDPContainer**](LDPContainer.md)
-
-### Authorization
-
-[RemoteUser](../README.md#RemoteUser)
-
-### HTTP request headers
-
- - **Content-Type**: application/json+ld
- - **Accept**: application/json+ld
 
 <a name="healthCheck"></a>
 # **healthCheck**

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -4,18 +4,358 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**createGroup**](LDPApi.md#createGroup) | **POST** /repository | Create new Group within the base container.
+[**createResource**](LDPApi.md#createResource) | **POST** /repository/{groupID} | Create a resource within a Group.
+[**createUser**](LDPApi.md#createUser) | **POST** /repository/users | Create a user within Sinopia.
+[**deleteGroup**](LDPApi.md#deleteGroup) | **DELETE** /repository/{groupID} | Delete an Group.
+[**deleteResource**](LDPApi.md#deleteResource) | **DELETE** /repository/{groupID}/{resourceID} | Delete a Resource.
+[**deleteUser**](LDPApi.md#deleteUser) | **DELETE** /repository/users/{userID} | Delete a User.
 [**getBase**](LDPApi.md#getBase) | **GET** /repository | Get metadata for the base container.
-[**repositoryGroupIDDelete**](LDPApi.md#repositoryGroupIDDelete) | **DELETE** /repository/{groupID} | 
-[**repositoryGroupIDHead**](LDPApi.md#repositoryGroupIDHead) | **HEAD** /repository/{groupID} | 
-[**repositoryGroupIDOptions**](LDPApi.md#repositoryGroupIDOptions) | **OPTIONS** /repository/{groupID} | 
-[**repositoryGroupIDPatch**](LDPApi.md#repositoryGroupIDPatch) | **PATCH** /repository/{groupID} | 
-[**repositoryGroupIDPost**](LDPApi.md#repositoryGroupIDPost) | **POST** /repository/{groupID} | Create new Group.
-[**repositoryGroupIDPut**](LDPApi.md#repositoryGroupIDPut) | **PUT** /repository/{groupID} | 
-[**repositoryHead**](LDPApi.md#repositoryHead) | **HEAD** /repository | Get headers only of base container request.
-[**repositoryOptions**](LDPApi.md#repositoryOptions) | **OPTIONS** /repository | 
-[**repositoryPost**](LDPApi.md#repositoryPost) | **POST** /repository | Create new Group within the base container.
-[**repositoryPut**](LDPApi.md#repositoryPut) | **PUT** /repository | Update metadata on base container.
+[**getGroup**](LDPApi.md#getGroup) | **GET** /repository/{groupID} | Get metadata (RDF) for a given Group.
+[**getResource**](LDPApi.md#getResource) | **GET** /repository/{groupID}/{resourceID} | Get metadata (RDF) for a given resource.
+[**getUser**](LDPApi.md#getUser) | **GET** /repository/users/{userID} | Get metadata (RDF) for a given user.
+[**getUsers**](LDPApi.md#getUsers) | **GET** /repository/users | Get metadata (RDF) for the Sinopia users container.
+[**headBase**](LDPApi.md#headBase) | **HEAD** /repository | Get headers only for base container GET request.
+[**headGroup**](LDPApi.md#headGroup) | **HEAD** /repository/{groupID} | Get headers only for a group GET request.
+[**headResource**](LDPApi.md#headResource) | **HEAD** /repository/{groupID}/{resourceID} | Get headers only for a resource GET request.
+[**headUser**](LDPApi.md#headUser) | **HEAD** /repository/users/{userID} | Get headers only for a user GET request.
+[**headUsers**](LDPApi.md#headUsers) | **HEAD** /repository/users | Get headers only for a Sinopia users&#39; container GET request.
+[**optionsBase**](LDPApi.md#optionsBase) | **OPTIONS** /repository | HTTP Options for base container.
+[**optionsGroup**](LDPApi.md#optionsGroup) | **OPTIONS** /repository/{groupID} | HTTP Options for group.
+[**optionsResource**](LDPApi.md#optionsResource) | **OPTIONS** /repository/{groupID}/{resourceID} | HTTP Options for resource.
+[**optionsUser**](LDPApi.md#optionsUser) | **OPTIONS** /repository/users/{userID} | HTTP Options for user.
+[**optionsUsers**](LDPApi.md#optionsUsers) | **OPTIONS** /repository/users | HTTP Options for Sinopia users&#39; container.
+[**updateBase**](LDPApi.md#updateBase) | **PUT** /repository | Update metadata on base container.
+[**updateGroup**](LDPApi.md#updateGroup) | **PUT** /repository/{groupID} | Update metadata on a group.
+[**updateResource**](LDPApi.md#updateResource) | **PUT** /repository/{groupID}/{resourceID} | Update metadata on a resource.
+[**updateUser**](LDPApi.md#updateUser) | **PUT** /repository/users/{userID} | Update metadata on a user.
+[**updateUsers**](LDPApi.md#updateUsers) | **PUT** /repository/users | Update metadata on the Sinopia users&#39; container.
 
+
+<a name="createGroup"></a>
+# **createGroup**
+> createGroup(slug, group, opts)
+
+Create new Group within the base container.
+
+Create a new Group (defined via JSON-LD in payload) within the base container.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var slug = "slug_example"; // String | The suggested URI path for the group.
+
+var group = new SinopiaServer.LDPContainer(); // LDPContainer | Group metadata to insert into base container and describe the group.
+
+var opts = { 
+  'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
+};
+apiInstance.createGroup(slug, group, opts).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **slug** | **String**| The suggested URI path for the group. | 
+ **group** | [**LDPContainer**](LDPContainer.md)| Group metadata to insert into base container and describe the group. | 
+ **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="createResource"></a>
+# **createResource**
+> createResource(groupID, resource, opts)
+
+Create a resource within a Group.
+
+Create a new resource (defined via JSON-LD in payload) within a supplied Group.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
+
+var resource = new SinopiaServer.Resource(); // Resource | Resource to insert into container
+
+var opts = { 
+  'slug': "slug_example", // String | The suggested URI path for the resource.
+  'contentType': "contentType_example" // String | Content-Type for the resource, with preference for JSON-LD.
+};
+apiInstance.createResource(groupID, resource, opts).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+ **resource** | [**Resource**](Resource.md)| Resource to insert into container | 
+ **slug** | **String**| The suggested URI path for the resource. | [optional] 
+ **contentType** | **String**| Content-Type for the resource, with preference for JSON-LD. | [optional] 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="createUser"></a>
+# **createUser**
+> createUser(user, opts)
+
+Create a user within Sinopia.
+
+Create a new user (defined via JSON-LD in payload) within Sinopia.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var user = new SinopiaServer.Resource(); // Resource | User to insert into Sinopia users' container.
+
+var opts = { 
+  'slug': "slug_example", // String | The suggested URI path for the user.
+  'contentType': "contentType_example" // String | Content-Type for the resource, with preference for JSON-LD.
+};
+apiInstance.createUser(user, opts).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **user** | [**Resource**](Resource.md)| User to insert into Sinopia users&#39; container. | 
+ **slug** | **String**| The suggested URI path for the user. | [optional] 
+ **contentType** | **String**| Content-Type for the resource, with preference for JSON-LD. | [optional] 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="deleteGroup"></a>
+# **deleteGroup**
+> deleteGroup(groupID)
+
+Delete an Group.
+
+Deletes an existing Group container. This Group URI cannot be reused.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
+
+apiInstance.deleteGroup(groupID).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="deleteResource"></a>
+# **deleteResource**
+> deleteResource(groupID, resourceID)
+
+Delete a Resource.
+
+Deletes an existing Resource. This Resource URI cannot be reused.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
+
+var resourceID = "resourceID_example"; // String | The UUID for the resource defined and managed within Sinopia.
+
+apiInstance.deleteResource(groupID, resourceID).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+ **resourceID** | **String**| The UUID for the resource defined and managed within Sinopia. | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="deleteUser"></a>
+# **deleteUser**
+> deleteUser(userID)
+
+Delete a User.
+
+Deletes an existing User. This User URI cannot be reused.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var userID = "userID_example"; // String | The ID for the User defined and managed within Sinopia.
+
+apiInstance.deleteUser(userID).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **userID** | **String**| The ID for the User defined and managed within Sinopia. | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
 
 <a name="getBase"></a>
 # **getBase**
@@ -61,13 +401,254 @@ This endpoint does not need any parameter.
  - **Content-Type**: application/json+ld
  - **Accept**: application/json+ld
 
-<a name="repositoryGroupIDDelete"></a>
-# **repositoryGroupIDDelete**
-> repositoryGroupIDDelete(groupID)
+<a name="getGroup"></a>
+# **getGroup**
+> LDPContainer getGroup(groupID)
 
+Get metadata (RDF) for a given Group.
 
+Get the RDF (default serialization is JSON-LD) for a given Group.
 
-Deletes LDP container 
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
+
+apiInstance.getGroup(groupID).then(function(data) {
+  console.log('API called successfully. Returned data: ' + data);
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+
+### Return type
+
+[**LDPContainer**](LDPContainer.md)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="getResource"></a>
+# **getResource**
+> Resource getResource(groupID, resourceID)
+
+Get metadata (RDF) for a given resource.
+
+Get the RDF (default serialization is JSON-LD) for a given resource.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
+
+var resourceID = "resourceID_example"; // String | The UUID for the resource defined and managed within Sinopia.
+
+apiInstance.getResource(groupID, resourceID).then(function(data) {
+  console.log('API called successfully. Returned data: ' + data);
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+ **resourceID** | **String**| The UUID for the resource defined and managed within Sinopia. | 
+
+### Return type
+
+[**Resource**](Resource.md)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="getUser"></a>
+# **getUser**
+> Resource getUser(userID)
+
+Get metadata (RDF) for a given user.
+
+Get the RDF (default serialization is JSON-LD) for a given Sinopia user.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var userID = "userID_example"; // String | The ID for the User defined and managed within Sinopia.
+
+apiInstance.getUser(userID).then(function(data) {
+  console.log('API called successfully. Returned data: ' + data);
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **userID** | **String**| The ID for the User defined and managed within Sinopia. | 
+
+### Return type
+
+[**Resource**](Resource.md)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="getUsers"></a>
+# **getUsers**
+> LDPContainer getUsers()
+
+Get metadata (RDF) for the Sinopia users container.
+
+Get the RDF (default serialization is JSON-LD) for the Sinopia users&#39; container.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+apiInstance.getUsers().then(function(data) {
+  console.log('API called successfully. Returned data: ' + data);
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**LDPContainer**](LDPContainer.md)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="headBase"></a>
+# **headBase**
+> headBase()
+
+Get headers only for base container GET request.
+
+Gets the header values that would normally be found in the header of GET request on the base container.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+apiInstance.headBase().then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="headGroup"></a>
+# **headGroup**
+> headGroup(groupID)
+
+Get headers only for a group GET request.
+
+Gets the header values that would normally be found in the header of GET request on the given group.
 
 ### Example
 ```javascript
@@ -75,9 +656,9 @@ var SinopiaServer = require('sinopia_server');
 
 var apiInstance = new SinopiaServer.LDPApi();
 
-var groupID = 56; // Number | LDP Container to get
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
 
-apiInstance.repositoryGroupIDDelete(groupID).then(function() {
+apiInstance.headGroup(groupID).then(function() {
   console.log('API called successfully.');
 }, function(error) {
   console.error(error);
@@ -89,7 +670,7 @@ apiInstance.repositoryGroupIDDelete(groupID).then(function() {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **groupID** | **Number**| LDP Container to get | 
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
 
 ### Return type
 
@@ -104,13 +685,13 @@ No authorization required
  - **Content-Type**: application/json+ld
  - **Accept**: application/json+ld
 
-<a name="repositoryGroupIDHead"></a>
-# **repositoryGroupIDHead**
-> repositoryGroupIDHead(groupID)
+<a name="headResource"></a>
+# **headResource**
+> headResource(groupID, resourceID)
 
+Get headers only for a resource GET request.
 
-
-Gets the header values that would normally be found in the header of GET
+Gets the header values that would normally be found in the header of GET request on the given resource.
 
 ### Example
 ```javascript
@@ -118,9 +699,11 @@ var SinopiaServer = require('sinopia_server');
 
 var apiInstance = new SinopiaServer.LDPApi();
 
-var groupID = 56; // Number | LDP Container to get
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
 
-apiInstance.repositoryGroupIDHead(groupID).then(function() {
+var resourceID = "resourceID_example"; // String | The UUID for the resource defined and managed within Sinopia.
+
+apiInstance.headResource(groupID, resourceID).then(function() {
   console.log('API called successfully.');
 }, function(error) {
   console.error(error);
@@ -132,7 +715,8 @@ apiInstance.repositoryGroupIDHead(groupID).then(function() {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **groupID** | **Number**| LDP Container to get | 
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+ **resourceID** | **String**| The UUID for the resource defined and managed within Sinopia. | 
 
 ### Return type
 
@@ -147,13 +731,13 @@ No authorization required
  - **Content-Type**: application/json+ld
  - **Accept**: application/json+ld
 
-<a name="repositoryGroupIDOptions"></a>
-# **repositoryGroupIDOptions**
-> repositoryGroupIDOptions(groupID)
+<a name="headUser"></a>
+# **headUser**
+> headUser(userID)
 
+Get headers only for a user GET request.
 
-
-Gets options for HTTP methods to utilize for this container
+Gets the header values that would normally be found in the header of GET request on the given user.
 
 ### Example
 ```javascript
@@ -161,9 +745,9 @@ var SinopiaServer = require('sinopia_server');
 
 var apiInstance = new SinopiaServer.LDPApi();
 
-var groupID = 56; // Number | LDP Container to get
+var userID = "userID_example"; // String | The ID for the User defined and managed within Sinopia.
 
-apiInstance.repositoryGroupIDOptions(groupID).then(function() {
+apiInstance.headUser(userID).then(function() {
   console.log('API called successfully.');
 }, function(error) {
   console.error(error);
@@ -175,7 +759,7 @@ apiInstance.repositoryGroupIDOptions(groupID).then(function() {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **groupID** | **Number**| LDP Container to get | 
+ **userID** | **String**| The ID for the User defined and managed within Sinopia. | 
 
 ### Return type
 
@@ -190,170 +774,20 @@ No authorization required
  - **Content-Type**: application/json+ld
  - **Accept**: application/json+ld
 
-<a name="repositoryGroupIDPatch"></a>
-# **repositoryGroupIDPatch**
-> repositoryGroupIDPatch(groupID, resource)
+<a name="headUsers"></a>
+# **headUsers**
+> headUsers()
 
+Get headers only for a Sinopia users&#39; container GET request.
 
-
-Updates LDP container 
-
-### Example
-```javascript
-var SinopiaServer = require('sinopia_server');
-
-var apiInstance = new SinopiaServer.LDPApi();
-
-var groupID = 56; // Number | LDP Container to get
-
-var resource = new SinopiaServer.Resource(); // Resource | Resource to insert into container
-
-apiInstance.repositoryGroupIDPatch(groupID, resource).then(function() {
-  console.log('API called successfully.');
-}, function(error) {
-  console.error(error);
-});
-
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **groupID** | **Number**| LDP Container to get | 
- **resource** | [**Resource**](Resource.md)| Resource to insert into container | 
-
-### Return type
-
-null (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: application/json+ld
- - **Accept**: application/json+ld
-
-<a name="repositoryGroupIDPost"></a>
-# **repositoryGroupIDPost**
-> repositoryGroupIDPost(groupID, resource, opts)
-
-Create new Group.
-
-Create a resource (defined via JSON-LD in payload) within a Group.
+Gets the header values that would normally be found in the header of GET request on the Sinopia users&#39; container.
 
 ### Example
 ```javascript
 var SinopiaServer = require('sinopia_server');
 
 var apiInstance = new SinopiaServer.LDPApi();
-
-var groupID = "groupID_example"; // String | The group (ldp:Container) who is defining it's own resources or graph within Sinopia.
-
-var resource = new SinopiaServer.Resource(); // Resource | Resource to insert into container
-
-var opts = { 
-  'slug': "slug_example", // String | Suggested URI for resource
-  'contentType': "contentType_example" // String | Content-Type of resource
-};
-apiInstance.repositoryGroupIDPost(groupID, resource, opts).then(function() {
-  console.log('API called successfully.');
-}, function(error) {
-  console.error(error);
-});
-
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **groupID** | **String**| The group (ldp:Container) who is defining it&#39;s own resources or graph within Sinopia. | 
- **resource** | [**Resource**](Resource.md)| Resource to insert into container | 
- **slug** | **String**| Suggested URI for resource | [optional] 
- **contentType** | **String**| Content-Type of resource | [optional] 
-
-### Return type
-
-null (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: application/json+ld
- - **Accept**: application/json+ld
-
-<a name="repositoryGroupIDPut"></a>
-# **repositoryGroupIDPut**
-> repositoryGroupIDPut(groupID, resource, opts)
-
-
-
-Updates the group description.
-
-### Example
-```javascript
-var SinopiaServer = require('sinopia_server');
-
-var apiInstance = new SinopiaServer.LDPApi();
-
-var groupID = 56; // Number | LDP Container to get
-
-var resource = new SinopiaServer.Resource(); // Resource | Resource to insert into container
-
-var opts = { 
-  'slug': "slug_example", // String | Suggested URI for resource
-  'contentType': "contentType_example" // String | Content-Type of resource
-};
-apiInstance.repositoryGroupIDPut(groupID, resource, opts).then(function() {
-  console.log('API called successfully.');
-}, function(error) {
-  console.error(error);
-});
-
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **groupID** | **Number**| LDP Container to get | 
- **resource** | [**Resource**](Resource.md)| Resource to insert into container | 
- **slug** | **String**| Suggested URI for resource | [optional] 
- **contentType** | **String**| Content-Type of resource | [optional] 
-
-### Return type
-
-null (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: application/json+ld
- - **Accept**: application/json+ld
-
-<a name="repositoryHead"></a>
-# **repositoryHead**
-> repositoryHead()
-
-Get headers only of base container request.
-
-Gets the header values that would normally be found in the header of GET on base container
-
-### Example
-```javascript
-var SinopiaServer = require('sinopia_server');
-
-var apiInstance = new SinopiaServer.LDPApi();
-apiInstance.repositoryHead().then(function() {
+apiInstance.headUsers().then(function() {
   console.log('API called successfully.');
 }, function(error) {
   console.error(error);
@@ -377,20 +811,27 @@ No authorization required
  - **Content-Type**: application/json+ld
  - **Accept**: application/json+ld
 
-<a name="repositoryOptions"></a>
-# **repositoryOptions**
-> repositoryOptions()
+<a name="optionsBase"></a>
+# **optionsBase**
+> optionsBase()
 
+HTTP Options for base container.
 
-
-Gets options for HTTP methods to utilize for the base container.
+Gets the available options for HTTP methods to utilize on the base container.
 
 ### Example
 ```javascript
 var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
 
 var apiInstance = new SinopiaServer.LDPApi();
-apiInstance.repositoryOptions().then(function() {
+apiInstance.optionsBase().then(function() {
   console.log('API called successfully.');
 }, function(error) {
   console.error(error);
@@ -407,34 +848,37 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[RemoteUser](../README.md#RemoteUser)
 
 ### HTTP request headers
 
  - **Content-Type**: application/json+ld
  - **Accept**: application/json+ld
 
-<a name="repositoryPost"></a>
-# **repositoryPost**
-> repositoryPost(groupMD, opts)
+<a name="optionsGroup"></a>
+# **optionsGroup**
+> optionsGroup(groupID)
 
-Create new Group within the base container.
+HTTP Options for group.
 
-Create a new Group (defined via JSON-LD in payload) within the base container.
+Gets the available options for HTTP methods to utilize on the given group.
 
 ### Example
 ```javascript
 var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
-var groupMD = new SinopiaServer.Resource(); // Resource | Group metadata to insert into base container and describe the group.
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
 
-var opts = { 
-  'slug': "slug_example", // String | The group (ldp:Container) who is defining it's own entities or graph within Sinopia.
-  'contentType': "contentType_example" // String | Content-Type of resource, with preference for JSON-LD.
-};
-apiInstance.repositoryPost(groupMD, opts).then(function() {
+apiInstance.optionsGroup(groupID).then(function() {
   console.log('API called successfully.');
 }, function(error) {
   console.error(error);
@@ -446,9 +890,7 @@ apiInstance.repositoryPost(groupMD, opts).then(function() {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **groupMD** | [**Resource**](Resource.md)| Group metadata to insert into base container and describe the group. | 
- **slug** | **String**| The group (ldp:Container) who is defining it&#39;s own entities or graph within Sinopia. | [optional] 
- **contentType** | **String**| Content-Type of resource, with preference for JSON-LD. | [optional] 
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
 
 ### Return type
 
@@ -456,16 +898,163 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[RemoteUser](../README.md#RemoteUser)
 
 ### HTTP request headers
 
  - **Content-Type**: application/json+ld
  - **Accept**: application/json+ld
 
-<a name="repositoryPut"></a>
-# **repositoryPut**
-> repositoryPut(metadata, opts)
+<a name="optionsResource"></a>
+# **optionsResource**
+> optionsResource(groupID, resourceID)
+
+HTTP Options for resource.
+
+Gets the available options for HTTP methods to utilize on the given resource.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
+
+var resourceID = "resourceID_example"; // String | The UUID for the resource defined and managed within Sinopia.
+
+apiInstance.optionsResource(groupID, resourceID).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+ **resourceID** | **String**| The UUID for the resource defined and managed within Sinopia. | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="optionsUser"></a>
+# **optionsUser**
+> optionsUser(userID)
+
+HTTP Options for user.
+
+Gets the available options for HTTP methods to utilize on the given user.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var userID = "userID_example"; // String | The ID for the User defined and managed within Sinopia.
+
+apiInstance.optionsUser(userID).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **userID** | **String**| The ID for the User defined and managed within Sinopia. | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="optionsUsers"></a>
+# **optionsUsers**
+> optionsUsers()
+
+HTTP Options for Sinopia users&#39; container.
+
+Gets the available options for HTTP methods to utilize on the Sinopia users&#39; container
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+apiInstance.optionsUsers().then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="updateBase"></a>
+# **updateBase**
+> updateBase(base, opts)
 
 Update metadata on base container.
 
@@ -474,15 +1063,22 @@ Update metadata of base container with new metadata defined via JSON-LD in paylo
 ### Example
 ```javascript
 var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
-var metadata = new SinopiaServer.Resource(); // Resource | New base container metadata to assert on the container.
+var base = new SinopiaServer.Resource(); // Resource | New base container metadata to assert on the container.
 
 var opts = { 
-  'contentType': "contentType_example" // String | Content-Type of resource
+  'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
 };
-apiInstance.repositoryPut(metadata, opts).then(function() {
+apiInstance.updateBase(base, opts).then(function() {
   console.log('API called successfully.');
 }, function(error) {
   console.error(error);
@@ -494,8 +1090,8 @@ apiInstance.repositoryPut(metadata, opts).then(function() {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **metadata** | [**Resource**](Resource.md)| New base container metadata to assert on the container. | 
- **contentType** | **String**| Content-Type of resource | [optional] 
+ **base** | [**Resource**](Resource.md)| New base container metadata to assert on the container. | 
+ **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
 
 ### Return type
 
@@ -503,7 +1099,235 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="updateGroup"></a>
+# **updateGroup**
+> updateGroup(groupID, group, opts)
+
+Update metadata on a group.
+
+Update metadata of a given group container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia. LDP Container to create the new resource within.
+
+var group = new SinopiaServer.LDPContainer(); // LDPContainer | Group metadata to replace existing description of the given group.
+
+var opts = { 
+  'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
+};
+apiInstance.updateGroup(groupID, group, opts).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. LDP Container to create the new resource within. | 
+ **group** | [**LDPContainer**](LDPContainer.md)| Group metadata to replace existing description of the given group. | 
+ **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="updateResource"></a>
+# **updateResource**
+> updateResource(groupID, resourceID, resource, opts)
+
+Update metadata on a resource.
+
+Update metadata of a given resource with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var groupID = "groupID_example"; // String | The group who is defining it's own resources or graph within Sinopia.
+
+var resourceID = "resourceID_example"; // String | The UUID for the resource defined and managed within Sinopia.
+
+var resource = new SinopiaServer.Resource(); // Resource | Resource metadata to replace existing description of the given group.
+
+var opts = { 
+  'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
+};
+apiInstance.updateResource(groupID, resourceID, resource, opts).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
+ **resourceID** | **String**| The UUID for the resource defined and managed within Sinopia. | 
+ **resource** | [**Resource**](Resource.md)| Resource metadata to replace existing description of the given group. | 
+ **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="updateUser"></a>
+# **updateUser**
+> updateUser(userID, user, opts)
+
+Update metadata on a user.
+
+Update metadata of a given Sinopua user with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var userID = "userID_example"; // String | The ID for the User defined and managed within Sinopia.
+
+var user = new SinopiaServer.Resource(); // Resource | User resource metadata to replace existing description of the given user.
+
+var opts = { 
+  'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
+};
+apiInstance.updateUser(userID, user, opts).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **userID** | **String**| The ID for the User defined and managed within Sinopia. | 
+ **user** | [**Resource**](Resource.md)| User resource metadata to replace existing description of the given user. | 
+ **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json+ld
+ - **Accept**: application/json+ld
+
+<a name="updateUsers"></a>
+# **updateUsers**
+> updateUsers(users, opts)
+
+Update metadata on the Sinopia users&#39; container.
+
+Update metadata of the Sinopia users&#39; container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+
+### Example
+```javascript
+var SinopiaServer = require('sinopia_server');
+var defaultClient = SinopiaServer.ApiClient.instance;
+
+// Configure API key authorization: RemoteUser
+var RemoteUser = defaultClient.authentications['RemoteUser'];
+RemoteUser.apiKey = 'YOUR API KEY';
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//RemoteUser.apiKeyPrefix = 'Token';
+
+var apiInstance = new SinopiaServer.LDPApi();
+
+var users = new SinopiaServer.LDPContainer(); // LDPContainer | Sinopia users' container metadata to replace existing description of the Sinopia users' container.
+
+var opts = { 
+  'contentType': "contentType_example" // String | Content-Type of Sinopia users' container metadata, with preference for JSON-LD.
+};
+apiInstance.updateUsers(users, opts).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **users** | [**LDPContainer**](LDPContainer.md)| Sinopia users&#39; container metadata to replace existing description of the Sinopia users&#39; container. | 
+ **contentType** | **String**| Content-Type of Sinopia users&#39; container metadata, with preference for JSON-LD. | [optional] 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[RemoteUser](../README.md#RemoteUser)
 
 ### HTTP request headers
 

--- a/sinopia_client/src/api/DefaultApi.js
+++ b/sinopia_client/src/api/DefaultApi.js
@@ -16,18 +16,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient', 'model/ErrorResponse', 'model/HealthCheckResponse', 'model/LDPContainer'], factory);
+    define(['ApiClient', 'model/HealthCheckResponse'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'), require('../model/ErrorResponse'), require('../model/HealthCheckResponse'), require('../model/LDPContainer'));
+    module.exports = factory(require('../ApiClient'), require('../model/HealthCheckResponse'));
   } else {
     // Browser globals (root is window)
     if (!root.SinopiaServer) {
       root.SinopiaServer = {};
     }
-    root.SinopiaServer.DefaultApi = factory(root.SinopiaServer.ApiClient, root.SinopiaServer.ErrorResponse, root.SinopiaServer.HealthCheckResponse, root.SinopiaServer.LDPContainer);
+    root.SinopiaServer.DefaultApi = factory(root.SinopiaServer.ApiClient, root.SinopiaServer.HealthCheckResponse);
   }
-}(this, function(ApiClient, ErrorResponse, HealthCheckResponse, LDPContainer) {
+}(this, function(ApiClient, HealthCheckResponse) {
   'use strict';
 
   /**
@@ -46,59 +46,6 @@
   var exports = function(apiClient) {
     this.apiClient = apiClient || ApiClient.instance;
 
-
-
-    /**
-     * Query for RDF about a Group.
-     * Get the RDF (default, JSON-LD) for a Group.
-     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia. LDP Container to get.
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LDPContainer} and HTTP response
-     */
-    this.getGroupWithHttpInfo = function(groupID) {
-      var postBody = null;
-
-      // verify the required parameter 'groupID' is set
-      if (groupID === undefined || groupID === null) {
-        throw new Error("Missing the required parameter 'groupID' when calling getGroup");
-      }
-
-
-      var pathParams = {
-        'groupID': groupID
-      };
-      var queryParams = {
-      };
-      var collectionQueryParams = {
-      };
-      var headerParams = {
-      };
-      var formParams = {
-      };
-
-      var authNames = ['RemoteUser'];
-      var contentTypes = ['application/json+ld'];
-      var accepts = ['application/json+ld'];
-      var returnType = LDPContainer;
-
-      return this.apiClient.callApi(
-        '/repository/{groupID}', 'GET',
-        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
-      );
-    }
-
-    /**
-     * Query for RDF about a Group.
-     * Get the RDF (default, JSON-LD) for a Group.
-     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia. LDP Container to get.
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/LDPContainer}
-     */
-    this.getGroup = function(groupID) {
-      return this.getGroupWithHttpInfo(groupID)
-        .then(function(response_and_data) {
-          return response_and_data.data;
-        });
-    }
 
 
     /**

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -49,6 +49,369 @@
 
 
     /**
+     * Create new Group within the base container.
+     * Create a new Group (defined via JSON-LD in payload) within the base container.
+     * @param {String} slug The suggested URI path for the group.
+     * @param {module:model/LDPContainer} group Group metadata to insert into base container and describe the group.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.createGroupWithHttpInfo = function(slug, group, opts) {
+      opts = opts || {};
+      var postBody = group;
+
+      // verify the required parameter 'slug' is set
+      if (slug === undefined || slug === null) {
+        throw new Error("Missing the required parameter 'slug' when calling createGroup");
+      }
+
+      // verify the required parameter 'group' is set
+      if (group === undefined || group === null) {
+        throw new Error("Missing the required parameter 'group' when calling createGroup");
+      }
+
+
+      var pathParams = {
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+        'Slug': slug,
+        'Content-Type': opts['contentType']
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository', 'POST',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Create new Group within the base container.
+     * Create a new Group (defined via JSON-LD in payload) within the base container.
+     * @param {String} slug The suggested URI path for the group.
+     * @param {module:model/LDPContainer} group Group metadata to insert into base container and describe the group.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.createGroup = function(slug, group, opts) {
+      return this.createGroupWithHttpInfo(slug, group, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Create a resource within a Group.
+     * Create a new resource (defined via JSON-LD in payload) within a supplied Group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {module:model/Resource} resource Resource to insert into container
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.slug The suggested URI path for the resource.
+     * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.createResourceWithHttpInfo = function(groupID, resource, opts) {
+      opts = opts || {};
+      var postBody = resource;
+
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling createResource");
+      }
+
+      // verify the required parameter 'resource' is set
+      if (resource === undefined || resource === null) {
+        throw new Error("Missing the required parameter 'resource' when calling createResource");
+      }
+
+
+      var pathParams = {
+        'groupID': groupID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+        'Slug': opts['slug'],
+        'Content-Type': opts['contentType']
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}', 'POST',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Create a resource within a Group.
+     * Create a new resource (defined via JSON-LD in payload) within a supplied Group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {module:model/Resource} resource Resource to insert into container
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.slug The suggested URI path for the resource.
+     * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.createResource = function(groupID, resource, opts) {
+      return this.createResourceWithHttpInfo(groupID, resource, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Create a user within Sinopia.
+     * Create a new user (defined via JSON-LD in payload) within Sinopia.
+     * @param {module:model/Resource} user User to insert into Sinopia users&#39; container.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.slug The suggested URI path for the user.
+     * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.createUserWithHttpInfo = function(user, opts) {
+      opts = opts || {};
+      var postBody = user;
+
+      // verify the required parameter 'user' is set
+      if (user === undefined || user === null) {
+        throw new Error("Missing the required parameter 'user' when calling createUser");
+      }
+
+
+      var pathParams = {
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+        'Slug': opts['slug'],
+        'Content-Type': opts['contentType']
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/users', 'POST',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Create a user within Sinopia.
+     * Create a new user (defined via JSON-LD in payload) within Sinopia.
+     * @param {module:model/Resource} user User to insert into Sinopia users&#39; container.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.slug The suggested URI path for the user.
+     * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.createUser = function(user, opts) {
+      return this.createUserWithHttpInfo(user, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Delete an Group.
+     * Deletes an existing Group container. This Group URI cannot be reused.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.deleteGroupWithHttpInfo = function(groupID) {
+      var postBody = null;
+
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling deleteGroup");
+      }
+
+
+      var pathParams = {
+        'groupID': groupID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}', 'DELETE',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Delete an Group.
+     * Deletes an existing Group container. This Group URI cannot be reused.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.deleteGroup = function(groupID) {
+      return this.deleteGroupWithHttpInfo(groupID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Delete a Resource.
+     * Deletes an existing Resource. This Resource URI cannot be reused.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.deleteResourceWithHttpInfo = function(groupID, resourceID) {
+      var postBody = null;
+
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling deleteResource");
+      }
+
+      // verify the required parameter 'resourceID' is set
+      if (resourceID === undefined || resourceID === null) {
+        throw new Error("Missing the required parameter 'resourceID' when calling deleteResource");
+      }
+
+
+      var pathParams = {
+        'groupID': groupID,
+        'resourceID': resourceID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}/{resourceID}', 'DELETE',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Delete a Resource.
+     * Deletes an existing Resource. This Resource URI cannot be reused.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.deleteResource = function(groupID, resourceID) {
+      return this.deleteResourceWithHttpInfo(groupID, resourceID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Delete a User.
+     * Deletes an existing User. This User URI cannot be reused.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.deleteUserWithHttpInfo = function(userID) {
+      var postBody = null;
+
+      // verify the required parameter 'userID' is set
+      if (userID === undefined || userID === null) {
+        throw new Error("Missing the required parameter 'userID' when calling deleteUser");
+      }
+
+
+      var pathParams = {
+        'userID': userID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/users/{userID}', 'DELETE',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Delete a User.
+     * Deletes an existing User. This User URI cannot be reused.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.deleteUser = function(userID) {
+      return this.deleteUserWithHttpInfo(userID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
      * Get metadata for the base container.
      * Get the RDF metadata (default serialization is JSON-LD) for the base container.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LDPContainer} and HTTP response
@@ -94,16 +457,17 @@
 
 
     /**
-     * Deletes LDP container 
-     * @param {Number} groupID LDP Container to get
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     * Get metadata (RDF) for a given Group.
+     * Get the RDF (default serialization is JSON-LD) for a given Group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LDPContainer} and HTTP response
      */
-    this.repositoryGroupIDDeleteWithHttpInfo = function(groupID) {
+    this.getGroupWithHttpInfo = function(groupID) {
       var postBody = null;
 
       // verify the required parameter 'groupID' is set
       if (groupID === undefined || groupID === null) {
-        throw new Error("Missing the required parameter 'groupID' when calling repositoryGroupIDDelete");
+        throw new Error("Missing the required parameter 'groupID' when calling getGroup");
       }
 
 
@@ -119,25 +483,26 @@
       var formParams = {
       };
 
-      var authNames = [];
+      var authNames = ['RemoteUser'];
       var contentTypes = ['application/json+ld'];
       var accepts = ['application/json+ld'];
-      var returnType = null;
+      var returnType = LDPContainer;
 
       return this.apiClient.callApi(
-        '/repository/{groupID}', 'DELETE',
+        '/repository/{groupID}', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
 
     /**
-     * Deletes LDP container 
-     * @param {Number} groupID LDP Container to get
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     * Get metadata (RDF) for a given Group.
+     * Get the RDF (default serialization is JSON-LD) for a given Group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/LDPContainer}
      */
-    this.repositoryGroupIDDelete = function(groupID) {
-      return this.repositoryGroupIDDeleteWithHttpInfo(groupID)
+    this.getGroup = function(groupID) {
+      return this.getGroupWithHttpInfo(groupID)
         .then(function(response_and_data) {
           return response_and_data.data;
         });
@@ -145,16 +510,221 @@
 
 
     /**
-     * Gets the header values that would normally be found in the header of GET
-     * @param {Number} groupID LDP Container to get
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     * Get metadata (RDF) for a given resource.
+     * Get the RDF (default serialization is JSON-LD) for a given resource.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/Resource} and HTTP response
      */
-    this.repositoryGroupIDHeadWithHttpInfo = function(groupID) {
+    this.getResourceWithHttpInfo = function(groupID, resourceID) {
       var postBody = null;
 
       // verify the required parameter 'groupID' is set
       if (groupID === undefined || groupID === null) {
-        throw new Error("Missing the required parameter 'groupID' when calling repositoryGroupIDHead");
+        throw new Error("Missing the required parameter 'groupID' when calling getResource");
+      }
+
+      // verify the required parameter 'resourceID' is set
+      if (resourceID === undefined || resourceID === null) {
+        throw new Error("Missing the required parameter 'resourceID' when calling getResource");
+      }
+
+
+      var pathParams = {
+        'groupID': groupID,
+        'resourceID': resourceID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = Resource;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}/{resourceID}', 'GET',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Get metadata (RDF) for a given resource.
+     * Get the RDF (default serialization is JSON-LD) for a given resource.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/Resource}
+     */
+    this.getResource = function(groupID, resourceID) {
+      return this.getResourceWithHttpInfo(groupID, resourceID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Get metadata (RDF) for a given user.
+     * Get the RDF (default serialization is JSON-LD) for a given Sinopia user.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/Resource} and HTTP response
+     */
+    this.getUserWithHttpInfo = function(userID) {
+      var postBody = null;
+
+      // verify the required parameter 'userID' is set
+      if (userID === undefined || userID === null) {
+        throw new Error("Missing the required parameter 'userID' when calling getUser");
+      }
+
+
+      var pathParams = {
+        'userID': userID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = Resource;
+
+      return this.apiClient.callApi(
+        '/repository/users/{userID}', 'GET',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Get metadata (RDF) for a given user.
+     * Get the RDF (default serialization is JSON-LD) for a given Sinopia user.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/Resource}
+     */
+    this.getUser = function(userID) {
+      return this.getUserWithHttpInfo(userID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Get metadata (RDF) for the Sinopia users container.
+     * Get the RDF (default serialization is JSON-LD) for the Sinopia users&#39; container.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LDPContainer} and HTTP response
+     */
+    this.getUsersWithHttpInfo = function() {
+      var postBody = null;
+
+
+      var pathParams = {
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = LDPContainer;
+
+      return this.apiClient.callApi(
+        '/repository/users', 'GET',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Get metadata (RDF) for the Sinopia users container.
+     * Get the RDF (default serialization is JSON-LD) for the Sinopia users&#39; container.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/LDPContainer}
+     */
+    this.getUsers = function() {
+      return this.getUsersWithHttpInfo()
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Get headers only for base container GET request.
+     * Gets the header values that would normally be found in the header of GET request on the base container.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.headBaseWithHttpInfo = function() {
+      var postBody = null;
+
+
+      var pathParams = {
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository', 'HEAD',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Get headers only for base container GET request.
+     * Gets the header values that would normally be found in the header of GET request on the base container.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.headBase = function() {
+      return this.headBaseWithHttpInfo()
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Get headers only for a group GET request.
+     * Gets the header values that would normally be found in the header of GET request on the given group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.headGroupWithHttpInfo = function(groupID) {
+      var postBody = null;
+
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling headGroup");
       }
 
 
@@ -183,12 +753,13 @@
     }
 
     /**
-     * Gets the header values that would normally be found in the header of GET
-     * @param {Number} groupID LDP Container to get
+     * Get headers only for a group GET request.
+     * Gets the header values that would normally be found in the header of GET request on the given group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    this.repositoryGroupIDHead = function(groupID) {
-      return this.repositoryGroupIDHeadWithHttpInfo(groupID)
+    this.headGroup = function(groupID) {
+      return this.headGroupWithHttpInfo(groupID)
         .then(function(response_and_data) {
           return response_and_data.data;
         });
@@ -196,21 +767,29 @@
 
 
     /**
-     * Gets options for HTTP methods to utilize for this container
-     * @param {Number} groupID LDP Container to get
+     * Get headers only for a resource GET request.
+     * Gets the header values that would normally be found in the header of GET request on the given resource.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    this.repositoryGroupIDOptionsWithHttpInfo = function(groupID) {
+    this.headResourceWithHttpInfo = function(groupID, resourceID) {
       var postBody = null;
 
       // verify the required parameter 'groupID' is set
       if (groupID === undefined || groupID === null) {
-        throw new Error("Missing the required parameter 'groupID' when calling repositoryGroupIDOptions");
+        throw new Error("Missing the required parameter 'groupID' when calling headResource");
+      }
+
+      // verify the required parameter 'resourceID' is set
+      if (resourceID === undefined || resourceID === null) {
+        throw new Error("Missing the required parameter 'resourceID' when calling headResource");
       }
 
 
       var pathParams = {
-        'groupID': groupID
+        'groupID': groupID,
+        'resourceID': resourceID
       };
       var queryParams = {
       };
@@ -227,19 +806,21 @@
       var returnType = null;
 
       return this.apiClient.callApi(
-        '/repository/{groupID}', 'OPTIONS',
+        '/repository/{groupID}/{resourceID}', 'HEAD',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
 
     /**
-     * Gets options for HTTP methods to utilize for this container
-     * @param {Number} groupID LDP Container to get
+     * Get headers only for a resource GET request.
+     * Gets the header values that would normally be found in the header of GET request on the given resource.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    this.repositoryGroupIDOptions = function(groupID) {
-      return this.repositoryGroupIDOptionsWithHttpInfo(groupID)
+    this.headResource = function(groupID, resourceID) {
+      return this.headResourceWithHttpInfo(groupID, resourceID)
         .then(function(response_and_data) {
           return response_and_data.data;
         });
@@ -247,27 +828,22 @@
 
 
     /**
-     * Updates LDP container 
-     * @param {Number} groupID LDP Container to get
-     * @param {module:model/Resource} resource Resource to insert into container
+     * Get headers only for a user GET request.
+     * Gets the header values that would normally be found in the header of GET request on the given user.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    this.repositoryGroupIDPatchWithHttpInfo = function(groupID, resource) {
-      var postBody = resource;
+    this.headUserWithHttpInfo = function(userID) {
+      var postBody = null;
 
-      // verify the required parameter 'groupID' is set
-      if (groupID === undefined || groupID === null) {
-        throw new Error("Missing the required parameter 'groupID' when calling repositoryGroupIDPatch");
-      }
-
-      // verify the required parameter 'resource' is set
-      if (resource === undefined || resource === null) {
-        throw new Error("Missing the required parameter 'resource' when calling repositoryGroupIDPatch");
+      // verify the required parameter 'userID' is set
+      if (userID === undefined || userID === null) {
+        throw new Error("Missing the required parameter 'userID' when calling headUser");
       }
 
 
       var pathParams = {
-        'groupID': groupID
+        'userID': userID
       };
       var queryParams = {
       };
@@ -284,20 +860,20 @@
       var returnType = null;
 
       return this.apiClient.callApi(
-        '/repository/{groupID}', 'PATCH',
+        '/repository/users/{userID}', 'HEAD',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
 
     /**
-     * Updates LDP container 
-     * @param {Number} groupID LDP Container to get
-     * @param {module:model/Resource} resource Resource to insert into container
+     * Get headers only for a user GET request.
+     * Gets the header values that would normally be found in the header of GET request on the given user.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    this.repositoryGroupIDPatch = function(groupID, resource) {
-      return this.repositoryGroupIDPatchWithHttpInfo(groupID, resource)
+    this.headUser = function(userID) {
+      return this.headUserWithHttpInfo(userID)
         .then(function(response_and_data) {
           return response_and_data.data;
         });
@@ -305,147 +881,11 @@
 
 
     /**
-     * Create new Group.
-     * Create a resource (defined via JSON-LD in payload) within a Group.
-     * @param {String} groupID The group (ldp:Container) who is defining it&#39;s own resources or graph within Sinopia.
-     * @param {module:model/Resource} resource Resource to insert into container
-     * @param {Object} opts Optional parameters
-     * @param {String} opts.slug Suggested URI for resource
-     * @param {String} opts.contentType Content-Type of resource
+     * Get headers only for a Sinopia users&#39; container GET request.
+     * Gets the header values that would normally be found in the header of GET request on the Sinopia users&#39; container.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    this.repositoryGroupIDPostWithHttpInfo = function(groupID, resource, opts) {
-      opts = opts || {};
-      var postBody = resource;
-
-      // verify the required parameter 'groupID' is set
-      if (groupID === undefined || groupID === null) {
-        throw new Error("Missing the required parameter 'groupID' when calling repositoryGroupIDPost");
-      }
-
-      // verify the required parameter 'resource' is set
-      if (resource === undefined || resource === null) {
-        throw new Error("Missing the required parameter 'resource' when calling repositoryGroupIDPost");
-      }
-
-
-      var pathParams = {
-        'groupID': groupID
-      };
-      var queryParams = {
-      };
-      var collectionQueryParams = {
-      };
-      var headerParams = {
-        'Slug': opts['slug'],
-        'Content-Type': opts['contentType']
-      };
-      var formParams = {
-      };
-
-      var authNames = [];
-      var contentTypes = ['application/json+ld'];
-      var accepts = ['application/json+ld'];
-      var returnType = null;
-
-      return this.apiClient.callApi(
-        '/repository/{groupID}', 'POST',
-        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
-      );
-    }
-
-    /**
-     * Create new Group.
-     * Create a resource (defined via JSON-LD in payload) within a Group.
-     * @param {String} groupID The group (ldp:Container) who is defining it&#39;s own resources or graph within Sinopia.
-     * @param {module:model/Resource} resource Resource to insert into container
-     * @param {Object} opts Optional parameters
-     * @param {String} opts.slug Suggested URI for resource
-     * @param {String} opts.contentType Content-Type of resource
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
-     */
-    this.repositoryGroupIDPost = function(groupID, resource, opts) {
-      return this.repositoryGroupIDPostWithHttpInfo(groupID, resource, opts)
-        .then(function(response_and_data) {
-          return response_and_data.data;
-        });
-    }
-
-
-    /**
-     * Updates the group description.
-     * @param {Number} groupID LDP Container to get
-     * @param {module:model/Resource} resource Resource to insert into container
-     * @param {Object} opts Optional parameters
-     * @param {String} opts.slug Suggested URI for resource
-     * @param {String} opts.contentType Content-Type of resource
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
-     */
-    this.repositoryGroupIDPutWithHttpInfo = function(groupID, resource, opts) {
-      opts = opts || {};
-      var postBody = resource;
-
-      // verify the required parameter 'groupID' is set
-      if (groupID === undefined || groupID === null) {
-        throw new Error("Missing the required parameter 'groupID' when calling repositoryGroupIDPut");
-      }
-
-      // verify the required parameter 'resource' is set
-      if (resource === undefined || resource === null) {
-        throw new Error("Missing the required parameter 'resource' when calling repositoryGroupIDPut");
-      }
-
-
-      var pathParams = {
-        'groupID': groupID
-      };
-      var queryParams = {
-      };
-      var collectionQueryParams = {
-      };
-      var headerParams = {
-        'Slug': opts['slug'],
-        'Content-Type': opts['contentType']
-      };
-      var formParams = {
-      };
-
-      var authNames = [];
-      var contentTypes = ['application/json+ld'];
-      var accepts = ['application/json+ld'];
-      var returnType = null;
-
-      return this.apiClient.callApi(
-        '/repository/{groupID}', 'PUT',
-        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
-      );
-    }
-
-    /**
-     * Updates the group description.
-     * @param {Number} groupID LDP Container to get
-     * @param {module:model/Resource} resource Resource to insert into container
-     * @param {Object} opts Optional parameters
-     * @param {String} opts.slug Suggested URI for resource
-     * @param {String} opts.contentType Content-Type of resource
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
-     */
-    this.repositoryGroupIDPut = function(groupID, resource, opts) {
-      return this.repositoryGroupIDPutWithHttpInfo(groupID, resource, opts)
-        .then(function(response_and_data) {
-          return response_and_data.data;
-        });
-    }
-
-
-    /**
-     * Get headers only of base container request.
-     * Gets the header values that would normally be found in the header of GET on base container
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
-     */
-    this.repositoryHeadWithHttpInfo = function() {
+    this.headUsersWithHttpInfo = function() {
       var postBody = null;
 
 
@@ -466,19 +906,19 @@
       var returnType = null;
 
       return this.apiClient.callApi(
-        '/repository', 'HEAD',
+        '/repository/users', 'HEAD',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
 
     /**
-     * Get headers only of base container request.
-     * Gets the header values that would normally be found in the header of GET on base container
+     * Get headers only for a Sinopia users&#39; container GET request.
+     * Gets the header values that would normally be found in the header of GET request on the Sinopia users&#39; container.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    this.repositoryHead = function() {
-      return this.repositoryHeadWithHttpInfo()
+    this.headUsers = function() {
+      return this.headUsersWithHttpInfo()
         .then(function(response_and_data) {
           return response_and_data.data;
         });
@@ -486,10 +926,11 @@
 
 
     /**
-     * Gets options for HTTP methods to utilize for the base container.
+     * HTTP Options for base container.
+     * Gets the available options for HTTP methods to utilize on the base container.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    this.repositoryOptionsWithHttpInfo = function() {
+    this.optionsBaseWithHttpInfo = function() {
       var postBody = null;
 
 
@@ -504,7 +945,7 @@
       var formParams = {
       };
 
-      var authNames = [];
+      var authNames = ['RemoteUser'];
       var contentTypes = ['application/json+ld'];
       var accepts = ['application/json+ld'];
       var returnType = null;
@@ -517,11 +958,12 @@
     }
 
     /**
-     * Gets options for HTTP methods to utilize for the base container.
+     * HTTP Options for base container.
+     * Gets the available options for HTTP methods to utilize on the base container.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    this.repositoryOptions = function() {
-      return this.repositoryOptionsWithHttpInfo()
+    this.optionsBase = function() {
+      return this.optionsBaseWithHttpInfo()
         .then(function(response_and_data) {
           return response_and_data.data;
         });
@@ -529,22 +971,179 @@
 
 
     /**
-     * Create new Group within the base container.
-     * Create a new Group (defined via JSON-LD in payload) within the base container.
-     * @param {module:model/Resource} groupMD Group metadata to insert into base container and describe the group.
-     * @param {Object} opts Optional parameters
-     * @param {String} opts.slug The group (ldp:Container) who is defining it&#39;s own entities or graph within Sinopia.
-     * @param {String} opts.contentType Content-Type of resource, with preference for JSON-LD.
+     * HTTP Options for group.
+     * Gets the available options for HTTP methods to utilize on the given group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    this.repositoryPostWithHttpInfo = function(groupMD, opts) {
-      opts = opts || {};
-      var postBody = groupMD;
+    this.optionsGroupWithHttpInfo = function(groupID) {
+      var postBody = null;
 
-      // verify the required parameter 'groupMD' is set
-      if (groupMD === undefined || groupMD === null) {
-        throw new Error("Missing the required parameter 'groupMD' when calling repositoryPost");
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling optionsGroup");
       }
+
+
+      var pathParams = {
+        'groupID': groupID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}', 'OPTIONS',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * HTTP Options for group.
+     * Gets the available options for HTTP methods to utilize on the given group.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.optionsGroup = function(groupID) {
+      return this.optionsGroupWithHttpInfo(groupID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * HTTP Options for resource.
+     * Gets the available options for HTTP methods to utilize on the given resource.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.optionsResourceWithHttpInfo = function(groupID, resourceID) {
+      var postBody = null;
+
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling optionsResource");
+      }
+
+      // verify the required parameter 'resourceID' is set
+      if (resourceID === undefined || resourceID === null) {
+        throw new Error("Missing the required parameter 'resourceID' when calling optionsResource");
+      }
+
+
+      var pathParams = {
+        'groupID': groupID,
+        'resourceID': resourceID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}/{resourceID}', 'OPTIONS',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * HTTP Options for resource.
+     * Gets the available options for HTTP methods to utilize on the given resource.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.optionsResource = function(groupID, resourceID) {
+      return this.optionsResourceWithHttpInfo(groupID, resourceID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * HTTP Options for user.
+     * Gets the available options for HTTP methods to utilize on the given user.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.optionsUserWithHttpInfo = function(userID) {
+      var postBody = null;
+
+      // verify the required parameter 'userID' is set
+      if (userID === undefined || userID === null) {
+        throw new Error("Missing the required parameter 'userID' when calling optionsUser");
+      }
+
+
+      var pathParams = {
+        'userID': userID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/users/{userID}', 'OPTIONS',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * HTTP Options for user.
+     * Gets the available options for HTTP methods to utilize on the given user.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.optionsUser = function(userID) {
+      return this.optionsUserWithHttpInfo(userID)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * HTTP Options for Sinopia users&#39; container.
+     * Gets the available options for HTTP methods to utilize on the Sinopia users&#39; container
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.optionsUsersWithHttpInfo = function() {
+      var postBody = null;
 
 
       var pathParams = {
@@ -554,35 +1153,29 @@
       var collectionQueryParams = {
       };
       var headerParams = {
-        'Slug': opts['slug'],
-        'Content-Type': opts['contentType']
       };
       var formParams = {
       };
 
-      var authNames = [];
+      var authNames = ['RemoteUser'];
       var contentTypes = ['application/json+ld'];
       var accepts = ['application/json+ld'];
       var returnType = null;
 
       return this.apiClient.callApi(
-        '/repository', 'POST',
+        '/repository/users', 'OPTIONS',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
 
     /**
-     * Create new Group within the base container.
-     * Create a new Group (defined via JSON-LD in payload) within the base container.
-     * @param {module:model/Resource} groupMD Group metadata to insert into base container and describe the group.
-     * @param {Object} opts Optional parameters
-     * @param {String} opts.slug The group (ldp:Container) who is defining it&#39;s own entities or graph within Sinopia.
-     * @param {String} opts.contentType Content-Type of resource, with preference for JSON-LD.
+     * HTTP Options for Sinopia users&#39; container.
+     * Gets the available options for HTTP methods to utilize on the Sinopia users&#39; container
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    this.repositoryPost = function(groupMD, opts) {
-      return this.repositoryPostWithHttpInfo(groupMD, opts)
+    this.optionsUsers = function() {
+      return this.optionsUsersWithHttpInfo()
         .then(function(response_and_data) {
           return response_and_data.data;
         });
@@ -592,18 +1185,18 @@
     /**
      * Update metadata on base container.
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
-     * @param {module:model/Resource} metadata New base container metadata to assert on the container.
+     * @param {module:model/Resource} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.contentType Content-Type of resource
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    this.repositoryPutWithHttpInfo = function(metadata, opts) {
+    this.updateBaseWithHttpInfo = function(base, opts) {
       opts = opts || {};
-      var postBody = metadata;
+      var postBody = base;
 
-      // verify the required parameter 'metadata' is set
-      if (metadata === undefined || metadata === null) {
-        throw new Error("Missing the required parameter 'metadata' when calling repositoryPut");
+      // verify the required parameter 'base' is set
+      if (base === undefined || base === null) {
+        throw new Error("Missing the required parameter 'base' when calling updateBase");
       }
 
 
@@ -619,7 +1212,7 @@
       var formParams = {
       };
 
-      var authNames = [];
+      var authNames = ['RemoteUser'];
       var contentTypes = ['application/json+ld'];
       var accepts = ['application/json+ld'];
       var returnType = null;
@@ -634,13 +1227,277 @@
     /**
      * Update metadata on base container.
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
-     * @param {module:model/Resource} metadata New base container metadata to assert on the container.
+     * @param {module:model/Resource} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.contentType Content-Type of resource
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    this.repositoryPut = function(metadata, opts) {
-      return this.repositoryPutWithHttpInfo(metadata, opts)
+    this.updateBase = function(base, opts) {
+      return this.updateBaseWithHttpInfo(base, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Update metadata on a group.
+     * Update metadata of a given group container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia. LDP Container to create the new resource within.
+     * @param {module:model/LDPContainer} group Group metadata to replace existing description of the given group.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.updateGroupWithHttpInfo = function(groupID, group, opts) {
+      opts = opts || {};
+      var postBody = group;
+
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling updateGroup");
+      }
+
+      // verify the required parameter 'group' is set
+      if (group === undefined || group === null) {
+        throw new Error("Missing the required parameter 'group' when calling updateGroup");
+      }
+
+
+      var pathParams = {
+        'groupID': groupID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+        'Content-Type': opts['contentType']
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}', 'PUT',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Update metadata on a group.
+     * Update metadata of a given group container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia. LDP Container to create the new resource within.
+     * @param {module:model/LDPContainer} group Group metadata to replace existing description of the given group.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.updateGroup = function(groupID, group, opts) {
+      return this.updateGroupWithHttpInfo(groupID, group, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Update metadata on a resource.
+     * Update metadata of a given resource with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @param {module:model/Resource} resource Resource metadata to replace existing description of the given group.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.updateResourceWithHttpInfo = function(groupID, resourceID, resource, opts) {
+      opts = opts || {};
+      var postBody = resource;
+
+      // verify the required parameter 'groupID' is set
+      if (groupID === undefined || groupID === null) {
+        throw new Error("Missing the required parameter 'groupID' when calling updateResource");
+      }
+
+      // verify the required parameter 'resourceID' is set
+      if (resourceID === undefined || resourceID === null) {
+        throw new Error("Missing the required parameter 'resourceID' when calling updateResource");
+      }
+
+      // verify the required parameter 'resource' is set
+      if (resource === undefined || resource === null) {
+        throw new Error("Missing the required parameter 'resource' when calling updateResource");
+      }
+
+
+      var pathParams = {
+        'groupID': groupID,
+        'resourceID': resourceID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+        'Content-Type': opts['contentType']
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/{groupID}/{resourceID}', 'PUT',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Update metadata on a resource.
+     * Update metadata of a given resource with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
+     * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
+     * @param {module:model/Resource} resource Resource metadata to replace existing description of the given group.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.updateResource = function(groupID, resourceID, resource, opts) {
+      return this.updateResourceWithHttpInfo(groupID, resourceID, resource, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Update metadata on a user.
+     * Update metadata of a given Sinopua user with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @param {module:model/Resource} user User resource metadata to replace existing description of the given user.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.updateUserWithHttpInfo = function(userID, user, opts) {
+      opts = opts || {};
+      var postBody = user;
+
+      // verify the required parameter 'userID' is set
+      if (userID === undefined || userID === null) {
+        throw new Error("Missing the required parameter 'userID' when calling updateUser");
+      }
+
+      // verify the required parameter 'user' is set
+      if (user === undefined || user === null) {
+        throw new Error("Missing the required parameter 'user' when calling updateUser");
+      }
+
+
+      var pathParams = {
+        'userID': userID
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+        'Content-Type': opts['contentType']
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/users/{userID}', 'PUT',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Update metadata on a user.
+     * Update metadata of a given Sinopua user with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {String} userID The ID for the User defined and managed within Sinopia.
+     * @param {module:model/Resource} user User resource metadata to replace existing description of the given user.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.updateUser = function(userID, user, opts) {
+      return this.updateUserWithHttpInfo(userID, user, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
+    /**
+     * Update metadata on the Sinopia users&#39; container.
+     * Update metadata of the Sinopia users&#39; container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {module:model/LDPContainer} users Sinopia users&#39; container metadata to replace existing description of the Sinopia users&#39; container.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Sinopia users&#39; container metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.updateUsersWithHttpInfo = function(users, opts) {
+      opts = opts || {};
+      var postBody = users;
+
+      // verify the required parameter 'users' is set
+      if (users === undefined || users === null) {
+        throw new Error("Missing the required parameter 'users' when calling updateUsers");
+      }
+
+
+      var pathParams = {
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+      };
+      var headerParams = {
+        'Content-Type': opts['contentType']
+      };
+      var formParams = {
+      };
+
+      var authNames = ['RemoteUser'];
+      var contentTypes = ['application/json+ld'];
+      var accepts = ['application/json+ld'];
+      var returnType = null;
+
+      return this.apiClient.callApi(
+        '/repository/users', 'PUT',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Update metadata on the Sinopia users&#39; container.
+     * Update metadata of the Sinopia users&#39; container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
+     * @param {module:model/LDPContainer} users Sinopia users&#39; container metadata to replace existing description of the Sinopia users&#39; container.
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.contentType Content-Type of Sinopia users&#39; container metadata, with preference for JSON-LD.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.updateUsers = function(users, opts) {
+      return this.updateUsersWithHttpInfo(users, opts)
         .then(function(response_and_data) {
           return response_and_data.data;
         });

--- a/sinopia_client/test/api/DefaultApi.spec.js
+++ b/sinopia_client/test/api/DefaultApi.spec.js
@@ -52,14 +52,6 @@
   }
 
   describe('DefaultApi', function() {
-    describe('getGroup', function() {
-      // it('should call getGroup successfully', function() {
-      //   return instance.getGroup('pcc')
-      //     .then(function(_data) {
-      //       expect().to.be();
-      //     });
-      // });
-    });
     describe('healthCheck', function() {
       beforeEach(function() {
         instance.apiClient.basePath = 'http://localhost:8081';

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -52,6 +52,66 @@
   }
 
   describe('LDPApi', function() {
+    describe('createGroup', function() {
+      it('should call createGroup successfully', function(done) {
+        //uncomment below and update the code to test createGroup
+        //instance.createGroup(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('createResource', function() {
+      it('should call createResource successfully', function(done) {
+        //uncomment below and update the code to test createResource
+        //instance.createResource(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('createUser', function() {
+      it('should call createUser successfully', function(done) {
+        //uncomment below and update the code to test createUser
+        //instance.createUser(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('deleteGroup', function() {
+      it('should call deleteGroup successfully', function(done) {
+        //uncomment below and update the code to test deleteGroup
+        //instance.deleteGroup(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('deleteResource', function() {
+      it('should call deleteResource successfully', function(done) {
+        //uncomment below and update the code to test deleteResource
+        //instance.deleteResource(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('deleteUser', function() {
+      it('should call deleteUser successfully', function(done) {
+        //uncomment below and update the code to test deleteUser
+        //instance.deleteUser(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
     describe('getBase', function() {
       // it('should call getBase successfully', function() {
       //   return instance.getBase()
@@ -60,92 +120,182 @@
       //     });
       // });
     });
-    describe('repositoryGroupIDDelete', function() {
-      it('should call repositoryGroupIDDelete successfully', function(done) {
-        //uncomment below and update the code to test repositoryGroupIDDelete
-        //instance.repositoryGroupIDDelete(function(error) {
+    describe('getGroup', function() {
+      it('should call getGroup successfully', function(done) {
+        //uncomment below and update the code to test getGroup
+        //instance.getGroup(function(error) {
         //  if (error) throw error;
         //expect().to.be();
         //});
         done();
       });
     });
-    describe('repositoryGroupIDHead', function() {
-      // it('should call repositoryGroupIDHead successfully', function() {
-      //   return instance.repositoryGroupIDHead('pcc')
+    describe('getResource', function() {
+      it('should call getResource successfully', function(done) {
+        //uncomment below and update the code to test getResource
+        //instance.getResource(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('getUser', function() {
+      it('should call getUser successfully', function(done) {
+        //uncomment below and update the code to test getUser
+        //instance.getUser(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('getUsers', function() {
+      it('should call getUsers successfully', function(done) {
+        //uncomment below and update the code to test getUsers
+        //instance.getUsers(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('headBase', function() {
+      // it('should call headBase successfully', function() {
+      //   return instance.headBase()
       //     .then(function(_data) {
       //       expect().to.be();
       //     });
       // });
     });
-    describe('repositoryGroupIDOptions', function() {
-      // it('should call repositoryGroupIDOptions successfully', function() {
-      //   return instance.repositoryGroupIDOptions('pcc')
+    describe('headGroup', function() {
+      // it('should call headGroup successfully', function() {
+      //   return instance.headGroup('pcc')
       //     .then(function(_data) {
       //       expect().to.be();
       //     });
       // });
     });
-    describe('repositoryGroupIDPatch', function() {
-      it('should call repositoryGroupIDPatch successfully', function(done) {
-        //uncomment below and update the code to test repositoryGroupIDPatch
-        //instance.repositoryGroupIDPatch(function(error) {
+    describe('headResource', function() {
+      it('should call headResource successfully', function(done) {
+        //uncomment below and update the code to test headResource
+        //instance.headResource(function(error) {
         //  if (error) throw error;
         //expect().to.be();
         //});
         done();
       });
     });
-    describe('repositoryGroupIDPost', function() {
-      it('should call repositoryGroupIDPost successfully', function(done) {
-        //uncomment below and update the code to test repositoryGroupIDPost
-        //instance.repositoryGroupIDPost(function(error) {
+    describe('headUser', function() {
+      it('should call headUser successfully', function(done) {
+        //uncomment below and update the code to test headUser
+        //instance.headUser(function(error) {
         //  if (error) throw error;
         //expect().to.be();
         //});
         done();
       });
     });
-    describe('repositoryGroupIDPut', function() {
-      it('should call repositoryGroupIDPut successfully', function(done) {
-        //uncomment below and update the code to test repositoryGroupIDPut
-        //instance.repositoryGroupIDPut(function(error) {
+    describe('headUsers', function() {
+      it('should call headUsers successfully', function(done) {
+        //uncomment below and update the code to test headUsers
+        //instance.headUsers(function(error) {
         //  if (error) throw error;
         //expect().to.be();
         //});
         done();
       });
     });
-    describe('repositoryHead', function() {
-      // it('should call repositoryHead successfully', function() {
-      //   return instance.repositoryHead()
+    describe('optionsBase', function() {
+      // it('should call optionsBase successfully', function() {
+      //   return instance.optionsBase()
       //     .then(function(_data) {
       //       expect().to.be();
       //     });
       // });
     });
-    describe('repositoryOptions', function() {
-      // it('should call repositoryOptions successfully', function() {
-      //   return instance.repositoryOptions()
+    describe('optionsGroup', function() {
+      // it('should call optionsGroup successfully', function() {
+      //   return instance.optionsGroup('pcc')
       //     .then(function(_data) {
       //       expect().to.be();
       //     });
       // });
     });
-    describe('repositoryPost', function() {
-      it('should call repositoryPost successfully', function(done) {
-        //uncomment below and update the code to test repositoryPost
-        //instance.repositoryPost(function(error) {
+    describe('optionsResource', function() {
+      it('should call optionsResource successfully', function(done) {
+        //uncomment below and update the code to test optionsResource
+        //instance.optionsResource(function(error) {
         //  if (error) throw error;
         //expect().to.be();
         //});
         done();
       });
     });
-    describe('repositoryPut', function() {
-      it('should call repositoryPut successfully', function(done) {
-        //uncomment below and update the code to test repositoryPut
-        //instance.repositoryPut(function(error) {
+    describe('optionsUser', function() {
+      it('should call optionsUser successfully', function(done) {
+        //uncomment below and update the code to test optionsUser
+        //instance.optionsUser(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('optionsUsers', function() {
+      it('should call optionsUsers successfully', function(done) {
+        //uncomment below and update the code to test optionsUsers
+        //instance.optionsUsers(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('updateBase', function() {
+      it('should call updateBase successfully', function(done) {
+        //uncomment below and update the code to test updateBase
+        //instance.updateBase(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('updateGroup', function() {
+      it('should call updateGroup successfully', function(done) {
+        //uncomment below and update the code to test updateGroup
+        //instance.updateGroup(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('updateResource', function() {
+      it('should call updateResource successfully', function(done) {
+        //uncomment below and update the code to test updateResource
+        //instance.updateResource(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('updateUser', function() {
+      it('should call updateUser successfully', function(done) {
+        //uncomment below and update the code to test updateUser
+        //instance.updateUser(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
+    describe('updateUsers', function() {
+      it('should call updateUsers successfully', function(done) {
+        //uncomment below and update the code to test updateUsers
+        //instance.updateUsers(function(error) {
         //  if (error) throw error;
         //expect().to.be();
         //});


### PR DESCRIPTION
follow on work to #21.  regenerates the JS client for the Sinopia Server API based on the swagger spec changes @cmharlow made.  merges what tests have been written into the re-generated test stubs.

~~WIP for now, because #21 should be merged before this.~~ rebased

closes #30 
