### PR TITLE
Allow URLs and administrative users to be specified in env vars

### DIFF
--- a/trellis/etc/config.yml
+++ b/trellis/etc/config.yml
@@ -70,13 +70,13 @@ namespaces: ${TRELLIS_NAMESPACES:-/opt/trellis/data/namespaces.json}
 
 # This may refer to a static base URL for resources. If left empty, the
 # base URL will reflect the Host header in the request.
-baseUrl:
+baseUrl: ${TRELLIS_BASE_URL:-}
 
 # This configuration will enable a WebSub "hub" header.
-hubUrl:
+hubUrl: ${TRELLIS_HUB_URL:-}
 
 auth:
-    adminUsers: [cmharlow]
+    adminUsers: ${TRELLIS_ADMIN_USERS:-[cmharlow]}
     webac:
         enabled: ${TRELLIS_AUTH_WEBAC_ENABLED:-true}
         cacheSize: ${TRELLIS_AUTH_WEBAC_CACHE_SIZE:-1000}


### PR DESCRIPTION
Without this change, specifically the change to the `baseUrl` value, pipeline integration tests fail due to testing over a network boundary, in which resources are created with a baseUrl of `localhost:8080`. Resources with that baseUrl are inaccessible to containerized services such as the pipeline, however. This change means we can assert a baseUrl of `platform:8080` despite what hostname the client/test uses, allowing the pipeline to run in the integration test.

This also requires a new version of the server docker container (for ld4p/trellis-ext-db) to be built and pushed, which I've already taken the liberty of doing.

connects to LD4P/sinopia_indexing_pipeline#7