### PR TITLE
Group and resource creation

### DIFF
--- a/sinopia_client/README.md
+++ b/sinopia_client/README.md
@@ -150,8 +150,8 @@ Class | Method | HTTP request | Description
  - [SinopiaServer.Resource](docs/Resource.md)
  - [SinopiaServer.ResourceContext](docs/ResourceContext.md)
  - [SinopiaServer.ResourceInfo](docs/ResourceInfo.md)
- - [SinopiaServer.SinopiaBaseContainer](docs/SinopiaBaseContainer.md)
- - [SinopiaServer.SinopiaBaseResourceContext](docs/SinopiaBaseResourceContext.md)
+ - [SinopiaServer.SinopiaBasicContainer](docs/SinopiaBasicContainer.md)
+ - [SinopiaServer.SinopiaBasicContainerContext](docs/SinopiaBasicContainerContext.md)
  - [SinopiaServer.Variable](docs/Variable.md)
 
 

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -405,7 +405,7 @@ This endpoint does not need any parameter.
 
 <a name="getGroup"></a>
 # **getGroup**
-> LDPContainer getGroup(groupID)
+> SinopiaBasicContainer getGroup(groupID)
 
 Get metadata (RDF) for a given Group.
 
@@ -442,7 +442,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**LDPContainer**](LDPContainer.md)
+[**SinopiaBasicContainer**](SinopiaBasicContainer.md)
 
 ### Authorization
 

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -359,7 +359,7 @@ null (empty response body)
 
 <a name="getBase"></a>
 # **getBase**
-> SinopiaBaseContainer getBase()
+> SinopiaBasicContainer getBase()
 
 Get metadata for the base container.
 
@@ -390,7 +390,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**SinopiaBaseContainer**](SinopiaBaseContainer.md)
+[**SinopiaBasicContainer**](SinopiaBasicContainer.md)
 
 ### Authorization
 
@@ -1073,7 +1073,7 @@ RemoteUser.apiKey = 'YOUR API KEY';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
-var base = new SinopiaServer.SinopiaBaseContainer(); // SinopiaBaseContainer | New base container metadata to assert on the container.
+var base = new SinopiaServer.SinopiaBasicContainer(); // SinopiaBasicContainer | New base container metadata to assert on the container.
 
 var opts = { 
   'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
@@ -1090,7 +1090,7 @@ apiInstance.updateBase(base, opts).then(function() {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **base** | [**SinopiaBaseContainer**](SinopiaBaseContainer.md)| New base container metadata to assert on the container. | 
+ **base** | [**SinopiaBasicContainer**](SinopiaBasicContainer.md)| New base container metadata to assert on the container. | 
  **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
 
 ### Return type

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -58,6 +58,7 @@ var slug = "slug_example"; // String | The suggested URI path for the group.
 var group = new SinopiaServer.LDPContainer(); // LDPContainer | Group metadata to insert into base container and describe the group.
 
 var opts = { 
+  'link': "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"", // String | specifies container type.
   'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
 };
 apiInstance.createGroup(slug, group, opts).then(function() {
@@ -74,6 +75,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **slug** | **String**| The suggested URI path for the group. | 
  **group** | [**LDPContainer**](LDPContainer.md)| Group metadata to insert into base container and describe the group. | 
+ **link** | **String**| specifies container type. | [optional] [default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;]
  **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
 
 ### Return type
@@ -1076,6 +1078,7 @@ var apiInstance = new SinopiaServer.LDPApi();
 var base = new SinopiaServer.SinopiaBasicContainer(); // SinopiaBasicContainer | New base container metadata to assert on the container.
 
 var opts = { 
+  'link': "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"", // String | specifies container type.  you probably shouldn't override this for this operation.
   'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
 };
 apiInstance.updateBase(base, opts).then(function() {
@@ -1091,6 +1094,7 @@ apiInstance.updateBase(base, opts).then(function() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **base** | [**SinopiaBasicContainer**](SinopiaBasicContainer.md)| New base container metadata to assert on the container. | 
+ **link** | **String**| specifies container type.  you probably shouldn&#39;t override this for this operation. | [optional] [default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;]
  **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
 
 ### Return type

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -58,7 +58,7 @@ var slug = "slug_example"; // String | The suggested URI path for the group.
 var group = new SinopiaServer.LDPContainer(); // LDPContainer | Group metadata to insert into base container and describe the group.
 
 var opts = { 
-  'link': "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"", // String | specifies container type.
+  'link': "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"", // String | specifies container type.  you probably shouldn't override this parameter for this operation.
   'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
 };
 apiInstance.createGroup(slug, group, opts).then(function() {
@@ -75,7 +75,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **slug** | **String**| The suggested URI path for the group. | 
  **group** | [**LDPContainer**](LDPContainer.md)| Group metadata to insert into base container and describe the group. | 
- **link** | **String**| specifies container type. | [optional] [default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;]
+ **link** | **String**| specifies container type.  you probably shouldn&#39;t override this parameter for this operation. | [optional] [default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;]
  **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
 
 ### Return type
@@ -1078,7 +1078,7 @@ var apiInstance = new SinopiaServer.LDPApi();
 var base = new SinopiaServer.SinopiaBasicContainer(); // SinopiaBasicContainer | New base container metadata to assert on the container.
 
 var opts = { 
-  'link': "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"", // String | specifies container type.  you probably shouldn't override this for this operation.
+  'link': "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"", // String | specifies container type.  you probably shouldn't override this parameter for this operation.
   'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
 };
 apiInstance.updateBase(base, opts).then(function() {
@@ -1094,7 +1094,7 @@ apiInstance.updateBase(base, opts).then(function() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **base** | [**SinopiaBasicContainer**](SinopiaBasicContainer.md)| New base container metadata to assert on the container. | 
- **link** | **String**| specifies container type.  you probably shouldn&#39;t override this for this operation. | [optional] [default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;]
+ **link** | **String**| specifies container type.  you probably shouldn&#39;t override this parameter for this operation. | [optional] [default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;]
  **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
 
 ### Return type

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -118,6 +118,7 @@ var resource = new SinopiaServer.Resource(); // Resource | Resource to insert in
 
 var opts = { 
   'slug': "slug_example", // String | The suggested URI path for the resource.
+  'link': "link_example", // String | specifies container type.
   'contentType': "contentType_example" // String | Content-Type for the resource, with preference for JSON-LD.
 };
 apiInstance.createResource(groupID, resource, opts).then(function() {
@@ -135,6 +136,7 @@ Name | Type | Description  | Notes
  **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
  **resource** | [**Resource**](Resource.md)| Resource to insert into container | 
  **slug** | **String**| The suggested URI path for the resource. | [optional] 
+ **link** | **String**| specifies container type. | [optional] 
  **contentType** | **String**| Content-Type for the resource, with preference for JSON-LD. | [optional] 
 
 ### Return type
@@ -147,7 +149,7 @@ null (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: application/ld+json
+ - **Content-Type**: Not defined
  - **Accept**: application/ld+json
 
 <a name="createUser"></a>

--- a/sinopia_client/docs/SinopiaBasicContainer.md
+++ b/sinopia_client/docs/SinopiaBasicContainer.md
@@ -1,10 +1,10 @@
-# SinopiaServer.SinopiaBaseContainer
+# SinopiaServer.SinopiaBasicContainer
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** |  | 
-**context** | [**SinopiaBaseResourceContext**](SinopiaBaseResourceContext.md) |  | 
+**context** | [**SinopiaBasicContainerContext**](SinopiaBasicContainerContext.md) |  | 
 **type** | **[String]** |  | 
 **rdfslabel** | **String** |  | 
 **label** | **String** |  | [optional] 

--- a/sinopia_client/docs/SinopiaBasicContainerContext.md
+++ b/sinopia_client/docs/SinopiaBasicContainerContext.md
@@ -1,4 +1,4 @@
-# SinopiaServer.SinopiaBaseResourceContext
+# SinopiaServer.SinopiaBasicContainerContext
 
 ## Properties
 Name | Type | Description | Notes

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -54,7 +54,7 @@
      * @param {String} slug The suggested URI path for the group.
      * @param {module:model/LDPContainer} group Group metadata to insert into base container and describe the group.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.link specifies container type. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
+     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this parameter for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
@@ -105,7 +105,7 @@
      * @param {String} slug The suggested URI path for the group.
      * @param {module:model/LDPContainer} group Group metadata to insert into base container and describe the group.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.link specifies container type. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
+     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this parameter for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
@@ -1190,7 +1190,7 @@
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
      * @param {module:model/SinopiaBasicContainer} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
+     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this parameter for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
@@ -1234,7 +1234,7 @@
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
      * @param {module:model/SinopiaBasicContainer} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
+     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this parameter for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -54,6 +54,7 @@
      * @param {String} slug The suggested URI path for the group.
      * @param {module:model/LDPContainer} group Group metadata to insert into base container and describe the group.
      * @param {Object} opts Optional parameters
+     * @param {String} opts.link specifies container type. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
@@ -80,6 +81,7 @@
       };
       var headerParams = {
         'Slug': slug,
+        'Link': opts['link'] ? opts['link'] : '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"', //MODIFIED AUTOGEN: codegen JS disregarded default param value
         'Content-Type': opts['contentType']
       };
       var formParams = {
@@ -103,6 +105,7 @@
      * @param {String} slug The suggested URI path for the group.
      * @param {module:model/LDPContainer} group Group metadata to insert into base container and describe the group.
      * @param {Object} opts Optional parameters
+     * @param {String} opts.link specifies container type. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
@@ -1187,6 +1190,7 @@
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
      * @param {module:model/SinopiaBasicContainer} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
+     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
@@ -1207,6 +1211,7 @@
       var collectionQueryParams = {
       };
       var headerParams = {
+        'Link': opts['link'] ? opts['link'] : '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"', //MODIFIED AUTOGEN: codegen JS disregarded default param value
         'Content-Type': opts['contentType']
       };
       var formParams = {
@@ -1229,6 +1234,7 @@
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
      * @param {module:model/SinopiaBasicContainer} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
+     * @param {String} opts.link specifies container type.  you probably shouldn&#39;t override this for this operation. (default to &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel&#x3D;&quot;type&quot;)
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -124,6 +124,7 @@
      * @param {module:model/Resource} resource Resource to insert into container
      * @param {Object} opts Optional parameters
      * @param {String} opts.slug The suggested URI path for the resource.
+     * @param {String} opts.link specifies container type.
      * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
@@ -151,13 +152,14 @@
       };
       var headerParams = {
         'Slug': opts['slug'],
+        'Link': opts['link'],
         'Content-Type': opts['contentType']
       };
       var formParams = {
       };
 
       var authNames = ['RemoteUser'];
-      var contentTypes = ['application/ld+json'];
+      var contentTypes = [];
       var accepts = ['application/ld+json'];
       var returnType = null;
 
@@ -175,6 +177,7 @@
      * @param {module:model/Resource} resource Resource to insert into container
      * @param {Object} opts Optional parameters
      * @param {String} opts.slug The suggested URI path for the resource.
+     * @param {String} opts.link specifies container type.
      * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -463,7 +463,7 @@
      * Get metadata (RDF) for a given Group.
      * Get the RDF (default serialization is JSON-LD) for a given Group.
      * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LDPContainer} and HTTP response
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/SinopiaBasicContainer} and HTTP response
      */
     this.getGroupWithHttpInfo = function(groupID) {
       var postBody = null;
@@ -489,7 +489,7 @@
       var authNames = ['RemoteUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
-      var returnType = LDPContainer;
+      var returnType = SinopiaBasicContainer;
 
       return this.apiClient.callApi(
         '/repository/{groupID}', 'GET',
@@ -502,7 +502,7 @@
      * Get metadata (RDF) for a given Group.
      * Get the RDF (default serialization is JSON-LD) for a given Group.
      * @param {String} groupID The group who is defining it&#39;s own resources or graph within Sinopia.
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/LDPContainer}
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/SinopiaBasicContainer}
      */
     this.getGroup = function(groupID) {
       return this.getGroupWithHttpInfo(groupID)

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -16,18 +16,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient', 'model/ErrorResponse', 'model/LDPContainer', 'model/Resource', 'model/SinopiaBaseContainer'], factory);
+    define(['ApiClient', 'model/ErrorResponse', 'model/LDPContainer', 'model/Resource', 'model/SinopiaBasicContainer'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'), require('../model/ErrorResponse'), require('../model/LDPContainer'), require('../model/Resource'), require('../model/SinopiaBaseContainer'));
+    module.exports = factory(require('../ApiClient'), require('../model/ErrorResponse'), require('../model/LDPContainer'), require('../model/Resource'), require('../model/SinopiaBasicContainer'));
   } else {
     // Browser globals (root is window)
     if (!root.SinopiaServer) {
       root.SinopiaServer = {};
     }
-    root.SinopiaServer.LDPApi = factory(root.SinopiaServer.ApiClient, root.SinopiaServer.ErrorResponse, root.SinopiaServer.LDPContainer, root.SinopiaServer.Resource, root.SinopiaServer.SinopiaBaseContainer);
+    root.SinopiaServer.LDPApi = factory(root.SinopiaServer.ApiClient, root.SinopiaServer.ErrorResponse, root.SinopiaServer.LDPContainer, root.SinopiaServer.Resource, root.SinopiaServer.SinopiaBasicContainer);
   }
-}(this, function(ApiClient, ErrorResponse, LDPContainer, Resource, SinopiaBaseContainer) {
+}(this, function(ApiClient, ErrorResponse, LDPContainer, Resource, SinopiaBasicContainer) {
   'use strict';
 
   /**
@@ -414,7 +414,7 @@
     /**
      * Get metadata for the base container.
      * Get the RDF metadata (default serialization is JSON-LD) for the base container.
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/SinopiaBaseContainer} and HTTP response
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/SinopiaBasicContainer} and HTTP response
      */
     this.getBaseWithHttpInfo = function() {
       var postBody = null;
@@ -434,7 +434,7 @@
       var authNames = ['RemoteUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
-      var returnType = SinopiaBaseContainer;
+      var returnType = SinopiaBasicContainer;
 
       return this.apiClient.callApi(
         '/repository', 'GET',
@@ -446,7 +446,7 @@
     /**
      * Get metadata for the base container.
      * Get the RDF metadata (default serialization is JSON-LD) for the base container.
-     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/SinopiaBaseContainer}
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/SinopiaBasicContainer}
      */
     this.getBase = function() {
       return this.getBaseWithHttpInfo()
@@ -1185,7 +1185,7 @@
     /**
      * Update metadata on base container.
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
-     * @param {module:model/SinopiaBaseContainer} base New base container metadata to assert on the container.
+     * @param {module:model/SinopiaBasicContainer} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
@@ -1227,7 +1227,7 @@
     /**
      * Update metadata on base container.
      * Update metadata of base container with new metadata defined via JSON-LD in payload. Performs overwrite, not partial update.
-     * @param {module:model/SinopiaBaseContainer} base New base container metadata to assert on the container.
+     * @param {module:model/SinopiaBasicContainer} base New base container metadata to assert on the container.
      * @param {Object} opts Optional parameters
      * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}

--- a/sinopia_client/src/index.js
+++ b/sinopia_client/src/index.js
@@ -16,12 +16,12 @@
 (function(factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient', 'model/Error', 'model/ErrorResponse', 'model/ErrorSource', 'model/HealthCheckResponse', 'model/LDPContainer', 'model/Resource', 'model/ResourceContext', 'model/ResourceInfo', 'model/SinopiaBaseContainer', 'model/SinopiaBaseResourceContext', 'model/Variable', 'api/DefaultApi', 'api/LDPApi'], factory);
+    define(['ApiClient', 'model/Error', 'model/ErrorResponse', 'model/ErrorSource', 'model/HealthCheckResponse', 'model/LDPContainer', 'model/Resource', 'model/ResourceContext', 'model/ResourceInfo', 'model/SinopiaBasicContainer', 'model/SinopiaBasicContainerContext', 'model/Variable', 'api/DefaultApi', 'api/LDPApi'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('./ApiClient'), require('./model/Error'), require('./model/ErrorResponse'), require('./model/ErrorSource'), require('./model/HealthCheckResponse'), require('./model/LDPContainer'), require('./model/Resource'), require('./model/ResourceContext'), require('./model/ResourceInfo'), require('./model/SinopiaBaseContainer'), require('./model/SinopiaBaseResourceContext'), require('./model/Variable'), require('./api/DefaultApi'), require('./api/LDPApi'));
+    module.exports = factory(require('./ApiClient'), require('./model/Error'), require('./model/ErrorResponse'), require('./model/ErrorSource'), require('./model/HealthCheckResponse'), require('./model/LDPContainer'), require('./model/Resource'), require('./model/ResourceContext'), require('./model/ResourceInfo'), require('./model/SinopiaBasicContainer'), require('./model/SinopiaBasicContainerContext'), require('./model/Variable'), require('./api/DefaultApi'), require('./api/LDPApi'));
   }
-}(function(ApiClient, Error, ErrorResponse, ErrorSource, HealthCheckResponse, LDPContainer, Resource, ResourceContext, ResourceInfo, SinopiaBaseContainer, SinopiaBaseResourceContext, Variable, DefaultApi, LDPApi) {
+}(function(ApiClient, Error, ErrorResponse, ErrorSource, HealthCheckResponse, LDPContainer, Resource, ResourceContext, ResourceInfo, SinopiaBasicContainer, SinopiaBasicContainerContext, Variable, DefaultApi, LDPApi) {
   'use strict';
 
   /**
@@ -102,15 +102,15 @@
      */
     ResourceInfo: ResourceInfo,
     /**
-     * The SinopiaBaseContainer model constructor.
-     * @property {module:model/SinopiaBaseContainer}
+     * The SinopiaBasicContainer model constructor.
+     * @property {module:model/SinopiaBasicContainer}
      */
-    SinopiaBaseContainer: SinopiaBaseContainer,
+    SinopiaBasicContainer: SinopiaBasicContainer,
     /**
-     * The SinopiaBaseResourceContext model constructor.
-     * @property {module:model/SinopiaBaseResourceContext}
+     * The SinopiaBasicContainerContext model constructor.
+     * @property {module:model/SinopiaBasicContainerContext}
      */
-    SinopiaBaseResourceContext: SinopiaBaseResourceContext,
+    SinopiaBasicContainerContext: SinopiaBasicContainerContext,
     /**
      * The Variable model constructor.
      * @property {module:model/Variable}

--- a/sinopia_client/src/model/SinopiaBasicContainer.js
+++ b/sinopia_client/src/model/SinopiaBasicContainer.js
@@ -16,35 +16,35 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient', 'model/SinopiaBaseResourceContext'], factory);
+    define(['ApiClient', 'model/SinopiaBasicContainerContext'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'), require('./SinopiaBaseResourceContext'));
+    module.exports = factory(require('../ApiClient'), require('./SinopiaBasicContainerContext'));
   } else {
     // Browser globals (root is window)
     if (!root.SinopiaServer) {
       root.SinopiaServer = {};
     }
-    root.SinopiaServer.SinopiaBaseContainer = factory(root.SinopiaServer.ApiClient, root.SinopiaServer.SinopiaBaseResourceContext);
+    root.SinopiaServer.SinopiaBasicContainer = factory(root.SinopiaServer.ApiClient, root.SinopiaServer.SinopiaBasicContainerContext);
   }
-}(this, function(ApiClient, SinopiaBaseResourceContext) {
+}(this, function(ApiClient, SinopiaBasicContainerContext) {
   'use strict';
 
 
 
 
   /**
-   * The SinopiaBaseContainer model module.
-   * @module model/SinopiaBaseContainer
+   * The SinopiaBasicContainer model module.
+   * @module model/SinopiaBasicContainer
    * @version 2.0.0
    */
 
   /**
-   * Constructs a new <code>SinopiaBaseContainer</code>.
-   * @alias module:model/SinopiaBaseContainer
+   * Constructs a new <code>SinopiaBasicContainer</code>.
+   * @alias module:model/SinopiaBasicContainer
    * @class
    * @param id {String} 
-   * @param context {module:model/SinopiaBaseResourceContext} 
+   * @param context {module:model/SinopiaBasicContainerContext} 
    * @param type {Array.<String>} 
    * @param rdfslabel {String} 
    */
@@ -59,11 +59,11 @@
   };
 
   /**
-   * Constructs a <code>SinopiaBaseContainer</code> from a plain JavaScript object, optionally creating a new instance.
+   * Constructs a <code>SinopiaBasicContainer</code> from a plain JavaScript object, optionally creating a new instance.
    * Copies all relevant properties from <code>data</code> to <code>obj</code> if supplied or a new instance if not.
    * @param {Object} data The plain JavaScript object bearing properties of interest.
-   * @param {module:model/SinopiaBaseContainer} obj Optional instance to populate.
-   * @return {module:model/SinopiaBaseContainer} The populated <code>SinopiaBaseContainer</code> instance.
+   * @param {module:model/SinopiaBasicContainer} obj Optional instance to populate.
+   * @return {module:model/SinopiaBasicContainer} The populated <code>SinopiaBasicContainer</code> instance.
    */
   exports.constructFromObject = function(data, obj) {
     if (data) {
@@ -73,7 +73,7 @@
         obj['@id'] = ApiClient.convertToType(data['@id'], 'String');
       }
       if (data.hasOwnProperty('@context')) {
-        obj['@context'] = SinopiaBaseResourceContext.constructFromObject(data['@context']);
+        obj['@context'] = SinopiaBasicContainerContext.constructFromObject(data['@context']);
       }
       if (data.hasOwnProperty('@type')) {
         obj['@type'] = ApiClient.convertToType(data['@type'], ['String']);
@@ -93,7 +93,7 @@
    */
   exports.prototype['@id'] = undefined;
   /**
-   * @member {module:model/SinopiaBaseResourceContext} @context
+   * @member {module:model/SinopiaBasicContainerContext} @context
    */
   exports.prototype['@context'] = undefined;
   /**

--- a/sinopia_client/src/model/SinopiaBasicContainerContext.js
+++ b/sinopia_client/src/model/SinopiaBasicContainerContext.js
@@ -25,7 +25,7 @@
     if (!root.SinopiaServer) {
       root.SinopiaServer = {};
     }
-    root.SinopiaServer.SinopiaBaseResourceContext = factory(root.SinopiaServer.ApiClient);
+    root.SinopiaServer.SinopiaBasicContainerContext = factory(root.SinopiaServer.ApiClient);
   }
 }(this, function(ApiClient) {
   'use strict';
@@ -34,14 +34,14 @@
 
 
   /**
-   * The SinopiaBaseResourceContext model module.
-   * @module model/SinopiaBaseResourceContext
+   * The SinopiaBasicContainerContext model module.
+   * @module model/SinopiaBasicContainerContext
    * @version 2.0.0
    */
 
   /**
-   * Constructs a new <code>SinopiaBaseResourceContext</code>.
-   * @alias module:model/SinopiaBaseResourceContext
+   * Constructs a new <code>SinopiaBasicContainerContext</code>.
+   * @alias module:model/SinopiaBasicContainerContext
    * @class
    * @param rdfs {String} 
    * @param ldp {String} 
@@ -54,11 +54,11 @@
   };
 
   /**
-   * Constructs a <code>SinopiaBaseResourceContext</code> from a plain JavaScript object, optionally creating a new instance.
+   * Constructs a <code>SinopiaBasicContainerContext</code> from a plain JavaScript object, optionally creating a new instance.
    * Copies all relevant properties from <code>data</code> to <code>obj</code> if supplied or a new instance if not.
    * @param {Object} data The plain JavaScript object bearing properties of interest.
-   * @param {module:model/SinopiaBaseResourceContext} obj Optional instance to populate.
-   * @return {module:model/SinopiaBaseResourceContext} The populated <code>SinopiaBaseResourceContext</code> instance.
+   * @param {module:model/SinopiaBasicContainerContext} obj Optional instance to populate.
+   * @return {module:model/SinopiaBasicContainerContext} The populated <code>SinopiaBasicContainerContext</code> instance.
    */
   exports.constructFromObject = function(data, obj) {
     if (data) {

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -56,6 +56,7 @@
 
   describe('LDPApi', function() {
     describe('createGroup', function() {
+      // need base container to exist, since group is created under that
       beforeEach(function() {
         let rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
         let baseRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server')

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -260,8 +260,8 @@
     describe('updateBase', function() {
       it('should call updateBase successfully', function() {
         var rand_num = Math.floor(Math.random() * 100)
-        var rsrcCtx = new SinopiaServer.SinopiaBaseResourceContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
-        var baseRsrc = new SinopiaServer.SinopiaBaseContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server' + rand_num)
+        var rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
+        var baseRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server' + rand_num)
 
         return instance.updateBase(baseRsrc).then(function(_responseData) {
           return instance.getBase()

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -56,15 +56,27 @@
 
   describe('LDPApi', function() {
     describe('createGroup', function() {
+      beforeEach(function() {
+        let rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
+        let baseRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server')
+
+        return instance.updateBase(baseRsrc).catch(function(err) { console.error(`Error setting up base container: ${err}`) })
+      });
+
       it('should call createGroup successfully', function() {
-        // created manually for now, but will need to do this as setup here (and teardown later?) to make stuff created under /repository not 404
-        // instance.updateBase(new SinopiaServer.Resource( , , new SinopiaServer.ResourceContext));
-        // var resources = [new SinopiaServer.Resource()];
-        // var group = new SinopiaServer.LDPContainer('', 'PCC Group', null, resources);
-        // return instance.createGroup('pcc', group, { contentType: 'application/ld+json' })
-        //   .then(function(_data) {
-        //     expect().to.be();
-        //   });
+        let rand_num = Math.floor(Math.random() * 100)
+        let rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
+        let groupRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'PCC Group' + rand_num)
+
+        return instance.createGroup('pcc', groupRsrc).then(function(_responseData) {
+          return instance.getGroup('pcc')
+            .then(function(responseData) {
+              expect(responseData['@id']).to.equal('http://localhost:8080/repository/pcc')
+              expect(responseData['@context']).to.deep.equal(groupRsrc['@context'])
+              expect(responseData['label']).to.equal(groupRsrc['rdfs:label'])
+            })
+        })
+        //TODO: attempting creation again should result in a response of HTTP 409 conflict
       });
     });
     describe('createResource', function() {
@@ -259,9 +271,9 @@
     });
     describe('updateBase', function() {
       it('should call updateBase successfully', function() {
-        var rand_num = Math.floor(Math.random() * 100)
-        var rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
-        var baseRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server' + rand_num)
+        let rand_num = Math.floor(Math.random() * 100)
+        let rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
+        let baseRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server' + rand_num)
 
         return instance.updateBase(baseRsrc).then(function(_responseData) {
           return instance.getBase()
@@ -272,9 +284,6 @@
               expect(responseData['label']).to.equal(baseRsrc['rdfs:label'])
             })
         })
-
-
-
       });
     });
     describe('updateGroup', function() {

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -79,7 +79,7 @@
               expect(responseData['label']).to.equal(groupRsrc['rdfs:label'])
             })
         })
-        //TODO: attempting creation again should result in a response of HTTP 409 conflict
+        //TODO: attempting creation again should result in a response of HTTP 409 conflict  https://github.com/LD4P/sinopia_server/issues/67
       });
     });
 
@@ -105,7 +105,7 @@
           let opts = {
             'slug': `profile${rand_num}`,
             'contentType': 'application/json',
-            'link': '<http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"'   //TODO: maybe these type strings should be centralized somewhere?
+            'link': '<http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"'   //TODO: centralize type strings?  https://github.com/LD4P/sinopia_server/issues/68
           }
 
           // createResourceWithHttpInfo because the thing we care about checking is in the response headers

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -108,11 +108,13 @@
             'link': '<http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"'   //TODO: maybe these type strings should be centralized somewhere?
           }
 
-          return instance.createResource('profiles', profileJson, opts)
-            .then(function(responseData) {
-              console.log(`responseData: ${responseData}`)
+          // createResourceWithHttpInfo because the thing we care about checking is in the response headers
+          return instance.createResourceWithHttpInfo('profiles', profileJson, opts)
+            .then(function(responseAndData) {
+              expect(responseAndData.response.statusCode).to.equal(201)
+              expect(responseAndData.response.headers.location).to.equal(`http://localhost:8080/repository/profiles/profile${rand_num}`)
             })
-            .catch(function(err) { console.error(`Error adding profile1: ${err}`) })
+            .catch(function(err) { console.error(`Error adding ${opts['slug']}: ${err}`) })
         });
       });
     });

--- a/sinopia_client/test/model/SinopiaBasicContainer.spec.js
+++ b/sinopia_client/test/model/SinopiaBasicContainer.spec.js
@@ -30,7 +30,7 @@
   var instance;
 
   beforeEach(function() {
-    instance = new SinopiaServer.SinopiaBaseResourceContext();
+    instance = new SinopiaServer.SinopiaBasicContainer();
   });
 
   var getProperty = function(object, getter, property) {
@@ -49,22 +49,40 @@
       object[property] = value;
   }
 
-  describe('SinopiaBaseResourceContext', function() {
-    it('should create an instance of SinopiaBaseResourceContext', function() {
-      // uncomment below and update the code to test SinopiaBaseResourceContext
-      //var instane = new SinopiaServer.SinopiaBaseResourceContext();
-      //expect(instance).to.be.a(SinopiaServer.SinopiaBaseResourceContext);
+  describe('SinopiaBasicContainer', function() {
+    it('should create an instance of SinopiaBasicContainer', function() {
+      // uncomment below and update the code to test SinopiaBasicContainer
+      //var instane = new SinopiaServer.SinopiaBasicContainer();
+      //expect(instance).to.be.a(SinopiaServer.SinopiaBasicContainer);
     });
 
-    it('should have the property rdfs (base name: "rdfs")', function() {
-      // uncomment below and update the code to test the property rdfs
-      //var instane = new SinopiaServer.SinopiaBaseResourceContext();
+    it('should have the property id (base name: "@id")', function() {
+      // uncomment below and update the code to test the property id
+      //var instane = new SinopiaServer.SinopiaBasicContainer();
       //expect(instance).to.be();
     });
 
-    it('should have the property ldp (base name: "ldp")', function() {
-      // uncomment below and update the code to test the property ldp
-      //var instane = new SinopiaServer.SinopiaBaseResourceContext();
+    it('should have the property context (base name: "@context")', function() {
+      // uncomment below and update the code to test the property context
+      //var instane = new SinopiaServer.SinopiaBasicContainer();
+      //expect(instance).to.be();
+    });
+
+    it('should have the property type (base name: "@type")', function() {
+      // uncomment below and update the code to test the property type
+      //var instane = new SinopiaServer.SinopiaBasicContainer();
+      //expect(instance).to.be();
+    });
+
+    it('should have the property rdfslabel (base name: "rdfs:label")', function() {
+      // uncomment below and update the code to test the property rdfslabel
+      //var instane = new SinopiaServer.SinopiaBasicContainer();
+      //expect(instance).to.be();
+    });
+
+    it('should have the property label (base name: "label")', function() {
+      // uncomment below and update the code to test the property label
+      //var instane = new SinopiaServer.SinopiaBasicContainer();
       //expect(instance).to.be();
     });
 

--- a/sinopia_client/test/model/SinopiaBasicContainerContext.spec.js
+++ b/sinopia_client/test/model/SinopiaBasicContainerContext.spec.js
@@ -30,7 +30,7 @@
   var instance;
 
   beforeEach(function() {
-    instance = new SinopiaServer.SinopiaBaseContainer();
+    instance = new SinopiaServer.SinopiaBasicContainerContext();
   });
 
   var getProperty = function(object, getter, property) {
@@ -49,40 +49,22 @@
       object[property] = value;
   }
 
-  describe('SinopiaBaseContainer', function() {
-    it('should create an instance of SinopiaBaseContainer', function() {
-      // uncomment below and update the code to test SinopiaBaseContainer
-      //var instane = new SinopiaServer.SinopiaBaseContainer();
-      //expect(instance).to.be.a(SinopiaServer.SinopiaBaseContainer);
+  describe('SinopiaBasicContainerContext', function() {
+    it('should create an instance of SinopiaBasicContainerContext', function() {
+      // uncomment below and update the code to test SinopiaBasicContainerContext
+      //var instane = new SinopiaServer.SinopiaBasicContainerContext();
+      //expect(instance).to.be.a(SinopiaServer.SinopiaBasicContainerContext);
     });
 
-    it('should have the property id (base name: "@id")', function() {
-      // uncomment below and update the code to test the property id
-      //var instane = new SinopiaServer.SinopiaBaseContainer();
+    it('should have the property rdfs (base name: "rdfs")', function() {
+      // uncomment below and update the code to test the property rdfs
+      //var instane = new SinopiaServer.SinopiaBasicContainerContext();
       //expect(instance).to.be();
     });
 
-    it('should have the property context (base name: "@context")', function() {
-      // uncomment below and update the code to test the property context
-      //var instane = new SinopiaServer.SinopiaBaseContainer();
-      //expect(instance).to.be();
-    });
-
-    it('should have the property type (base name: "@type")', function() {
-      // uncomment below and update the code to test the property type
-      //var instane = new SinopiaServer.SinopiaBaseContainer();
-      //expect(instance).to.be();
-    });
-
-    it('should have the property rdfslabel (base name: "rdfs:label")', function() {
-      // uncomment below and update the code to test the property rdfslabel
-      //var instane = new SinopiaServer.SinopiaBaseContainer();
-      //expect(instance).to.be();
-    });
-
-    it('should have the property label (base name: "label")', function() {
-      // uncomment below and update the code to test the property label
-      //var instane = new SinopiaServer.SinopiaBaseContainer();
+    it('should have the property ldp (base name: "ldp")', function() {
+      // uncomment below and update the code to test the property ldp
+      //var instane = new SinopiaServer.SinopiaBasicContainerContext();
       //expect(instance).to.be();
     });
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -39,7 +39,7 @@ paths:
               type: string
               format: URI
           schema:
-            $ref: '#/definitions/SinopiaBaseContainer'
+            $ref: '#/definitions/SinopiaBasicContainer'
         '404':
           description: Unable to find the base container.
           schema:
@@ -111,7 +111,7 @@ paths:
           description: New base container metadata to assert on the container.
           required: true
           schema:
-            $ref: '#/definitions/SinopiaBaseContainer'
+            $ref: '#/definitions/SinopiaBasicContainer'
         - name: Content-Type
           in: header
           description: Content-Type of Group metadata, with preference for JSON-LD.
@@ -1124,7 +1124,7 @@ definitions:
   # note: wanted to have a Sinopia: section for Sinopia-not-LDP models, but swagger-codegen just made a SinopiaModels
   # file and mashed together everything under it, instead of making a file for each model.  so, seems like we need to
   # do our namespacing via naming convention for one level, instead of hierarchy.
-  SinopiaBaseContainer:
+  SinopiaBasicContainer:
     required:
       - "@context"
       - "@id"
@@ -1135,7 +1135,7 @@ definitions:
         type: string
         format: uri
       "@context":
-        $ref: "#/definitions/SinopiaBaseResourceContext"
+        $ref: "#/definitions/SinopiaBasicContainerContext"
       "@type":
         type: array
         items:
@@ -1145,7 +1145,7 @@ definitions:
         type: string
       "label":
         type: string
-  SinopiaBaseResourceContext:
+  SinopiaBasicContainerContext:
     required:
       - rdfs
       - ldp

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -245,6 +245,7 @@ paths:
         - LDP
       security:
         - RemoteUser: []
+      consumes: [] # client must specify content type, can be json or ld+json, see params
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -263,6 +264,12 @@ paths:
           required: false
           type: string
           format: URI
+        - name: Link
+          in: header
+          description: specifies container type.
+          required: false
+          type: string
+          example: 'Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"'
         - name: Content-Type
           in: header
           description: Content-Type for the resource, with preference for JSON-LD.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -68,7 +68,7 @@ paths:
             $ref: '#/definitions/LDPContainer'
         - name: Link
           in: header
-          description: specifies container type.
+          description: specifies container type.  you probably shouldn't override this parameter for this operation.
           required: false
           type: string
           default: '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"'
@@ -120,7 +120,7 @@ paths:
             $ref: '#/definitions/SinopiaBasicContainer'
         - name: Link
           in: header
-          description: specifies container type.  you probably shouldn't override this for this operation.
+          description: specifies container type.  you probably shouldn't override this parameter for this operation.
           required: false
           type: string
           default: '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"'

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -230,7 +230,7 @@ paths:
               type: string
               format: URI
           schema:
-            $ref: '#/definitions/LDPContainer'
+            $ref: '#/definitions/SinopiaBasicContainer'
         '404':
           description: Unable to find the specified Group container.
           schema:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -66,6 +66,12 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/LDPContainer'
+        - name: Link
+          in: header
+          description: specifies container type.
+          required: false
+          type: string
+          default: '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"'
         - name: Content-Type
           in: header
           description: Content-Type of Group metadata, with preference for JSON-LD.
@@ -112,6 +118,12 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/SinopiaBasicContainer'
+        - name: Link
+          in: header
+          description: specifies container type.  you probably shouldn't override this for this operation.
+          required: false
+          type: string
+          default: '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"'
         - name: Content-Type
           in: header
           description: Content-Type of Group metadata, with preference for JSON-LD.


### PR DESCRIPTION
closes #35 (robustifying can be a follow on ticket, per TODO in code)

connects to #38 (in that i believe resource templates can be pushed into trellis the same way as profiles, since they're also non-RDF JSON blobs?  so this should illustrate the use case in #38 also?)
connects to #29 
connects to #41 

TODO:
- [x] ticket the TODOs in code
- [ ] regenerate spec stubs w/ updated swagger.yml def from this PR (SDK code was updated) (#69)

happy to remove the TODOs from code if people would prefer, i tend not to leave those in, but things are pretty messy and in flux, so i'm also fine with a "go back and fix/ticket TODOs" ticket for the end of the work cycle.  whatever people would prefer.