### PR TITLE
Send JWT from client / allow JWT authentication on CI server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.trellis-ext-db
+    environment:
+      TRELLIS_AUTH_JWT_ENABLED: 'true'
+      COGNITO_USER_POOL_ID: 'us-west-2_HUmNIdmhy'
+      AWS_COGNITO_REGION: 'us-west-2'
     ports:
       - 8080:8080
       - 8081:8081

--- a/sinopia_client/README.md
+++ b/sinopia_client/README.md
@@ -158,9 +158,10 @@ Class | Method | HTTP request | Description
 ## Documentation for Authorization
 
 
-### RemoteUser
+### CognitoUser
 
-- **Type**: API key
-- **API key parameter name**: On-Behalf-Of
-- **Location**: HTTP header
+- **Type**: OAuth
+- **Flow**: accessCode
+- **Authorization URL**: 
+- **Scopes**: N/A
 

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -45,11 +45,9 @@ Create a new Group (defined via JSON-LD in payload) within the base container.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -84,7 +82,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -104,11 +102,9 @@ Create a new resource (defined via JSON-LD in payload) within a supplied Group.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -145,7 +141,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -165,11 +161,9 @@ Create a new user (defined via JSON-LD in payload) within Sinopia.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -201,7 +195,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -221,11 +215,9 @@ Deletes an existing Group container. This Group URI cannot be reused.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -251,7 +243,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -271,11 +263,9 @@ Deletes an existing Resource. This Resource URI cannot be reused.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -304,7 +294,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -324,11 +314,9 @@ Deletes an existing User. This User URI cannot be reused.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -354,7 +342,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -374,11 +362,9 @@ Get the RDF metadata (default serialization is JSON-LD) for the base container.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 apiInstance.getBase().then(function(data) {
@@ -398,7 +384,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -418,11 +404,9 @@ Get the RDF (default serialization is JSON-LD) for a given Group.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -448,7 +432,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -468,11 +452,9 @@ Get the RDF (default serialization is JSON-LD) for a given resource.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -501,7 +483,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -521,11 +503,9 @@ Get the RDF (default serialization is JSON-LD) for a given Sinopia user.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -551,7 +531,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -571,11 +551,9 @@ Get the RDF (default serialization is JSON-LD) for the Sinopia users&#39; contai
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 apiInstance.getUsers().then(function(data) {
@@ -595,7 +573,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -615,11 +593,9 @@ Gets the header values that would normally be found in the header of GET request
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 apiInstance.headBase().then(function() {
@@ -639,7 +615,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -828,11 +804,9 @@ Gets the available options for HTTP methods to utilize on the base container.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 apiInstance.optionsBase().then(function() {
@@ -852,7 +826,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -872,11 +846,9 @@ Gets the available options for HTTP methods to utilize on the given group.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -902,7 +874,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -922,11 +894,9 @@ Gets the available options for HTTP methods to utilize on the given resource.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -955,7 +925,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -975,11 +945,9 @@ Gets the available options for HTTP methods to utilize on the given user.
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -1005,7 +973,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -1025,11 +993,9 @@ Gets the available options for HTTP methods to utilize on the Sinopia users&#39;
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 apiInstance.optionsUsers().then(function() {
@@ -1049,7 +1015,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -1069,11 +1035,9 @@ Update metadata of base container with new metadata defined via JSON-LD in paylo
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -1105,7 +1069,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -1125,11 +1089,9 @@ Update metadata of a given group container with new metadata defined via JSON-LD
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -1162,7 +1124,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -1182,11 +1144,9 @@ Update metadata of a given resource with new metadata defined via JSON-LD in pay
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -1222,7 +1182,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -1242,11 +1202,9 @@ Update metadata of a given Sinopua user with new metadata defined via JSON-LD in
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -1279,7 +1237,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 
@@ -1299,11 +1257,9 @@ Update metadata of the Sinopia users&#39; container with new metadata defined vi
 var SinopiaServer = require('sinopia_server');
 var defaultClient = SinopiaServer.ApiClient.instance;
 
-// Configure API key authorization: RemoteUser
-var RemoteUser = defaultClient.authentications['RemoteUser'];
-RemoteUser.apiKey = 'YOUR API KEY';
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//RemoteUser.apiKeyPrefix = 'Token';
+// Configure OAuth2 access token for authorization: CognitoUser
+var CognitoUser = defaultClient.authentications['CognitoUser'];
+CognitoUser.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new SinopiaServer.LDPApi();
 
@@ -1333,7 +1289,7 @@ null (empty response body)
 
 ### Authorization
 
-[RemoteUser](../README.md#RemoteUser)
+[CognitoUser](../README.md#CognitoUser)
 
 ### HTTP request headers
 

--- a/sinopia_client/src/ApiClient.js
+++ b/sinopia_client/src/ApiClient.js
@@ -55,7 +55,7 @@
      * @type {Array.<String>}
      */
     this.authentications = {
-      'RemoteUser': {type: 'apiKey', 'in': 'header', name: 'On-Behalf-Of'}
+      'CognitoUser': {type: 'oauth2'}
     };
     /**
      * The default HTTP headers to be included for all API calls.

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -87,7 +87,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -158,7 +158,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = [];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -221,7 +221,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -277,7 +277,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -337,7 +337,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -391,7 +391,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -437,7 +437,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = SinopiaBasicContainer;
@@ -489,7 +489,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = SinopiaBasicContainer;
@@ -549,7 +549,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = Resource;
@@ -603,7 +603,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = Resource;
@@ -649,7 +649,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = LDPContainer;
@@ -694,7 +694,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -951,7 +951,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1003,7 +1003,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1063,7 +1063,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1117,7 +1117,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1163,7 +1163,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1220,7 +1220,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1286,7 +1286,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1359,7 +1359,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1426,7 +1426,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;
@@ -1485,7 +1485,7 @@
       var formParams = {
       };
 
-      var authNames = ['RemoteUser'];
+      var authNames = ['CognitoUser'];
       var contentTypes = ['application/ld+json'];
       var accepts = ['application/ld+json'];
       var returnType = null;

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -356,6 +356,8 @@
         done();
       });
     });
+    //TODO:  auth tests.  will have to set JWT on client instance, e.g.
+    // instance.apiClient.authentications['CognitoUser'].accessToken = '<my secret base64 encoded JWT>'
   });
 
 }));

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -269,7 +269,9 @@ paths:
           description: specifies container type.
           required: false
           type: string
-          example: 'Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"'
+          example:
+            - '<http://www.w3.org/ns/ldp#RDFSource>; rel="type"'
+            - '<http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"'
         - name: Content-Type
           in: header
           description: Content-Type for the resource, with preference for JSON-LD.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -12,10 +12,9 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 securityDefinitions:
-  RemoteUser:
-    type: apiKey
-    in: header
-    name: On-Behalf-Of
+  CognitoUser:
+    type: oauth2
+    flow: accessCode
 paths:
   /repository:
     get:
@@ -25,7 +24,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       responses:
         '200':
           description: Successful base container response.
@@ -53,7 +52,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: Slug
           description: The suggested URI path for the group.
@@ -110,7 +109,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: Base
           in: body
@@ -160,7 +159,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       responses:
         "200":
           description: Successful response.
@@ -184,7 +183,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       responses:
         "200":
           description: Successful response.
@@ -210,7 +209,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -244,7 +243,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       consumes: [] # client must specify content type, can be json or ld+json, see params
       parameters:
         - name: groupID
@@ -310,7 +309,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia. LDP Container to create the new resource within.
@@ -361,7 +360,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -401,7 +400,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -461,7 +460,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -500,7 +499,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -556,7 +555,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -601,7 +600,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -671,7 +670,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       responses:
         '200':
           description: Successful group container response.
@@ -699,7 +698,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: User
           in: body
@@ -751,7 +750,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: Users
           in: body
@@ -792,7 +791,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       responses:
         "200":
           description: Successful response.
@@ -840,7 +839,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: userID
           description: The ID for the User defined and managed within Sinopia.
@@ -874,7 +873,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: userID
           description: The ID for the User defined and managed within Sinopia.
@@ -925,7 +924,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: userID
           description: The ID for the User defined and managed within Sinopia.
@@ -965,7 +964,7 @@ paths:
       tags:
         - LDP
       security:
-        - RemoteUser: []
+        - CognitoUser: []
       parameters:
         - name: userID
           description: The ID for the User defined and managed within Sinopia.

--- a/trellis/etc/config.yml
+++ b/trellis/etc/config.yml
@@ -83,7 +83,7 @@ auth:
         cacheExpireSeconds: ${TRELLIS_AUTH_WEBAC_CACHE_EXPIRE_SECONDS:-60}
     jwt:
         enabled: ${TRELLIS_AUTH_JWT_ENABLED:-false}
-        key: ${TRELLIS_AUTH_JWT_KEY:-}
+        jwks: https://cognito-idp.${AWS_COGNITO_REGION}.amazonaws.com/${COGNITO_USER_POOL_ID}/.well-known/jwks.json
     basic:
         enabled: ${TRELLIS_AUTH_BASIC_ENABLED:-true}
         usersFile: ${TRELLIS_AUTH_BASIC_USERS_FILE:-/opt/trellis/etc/users.auth}


### PR DESCRIPTION
* in swagger spec, replace `RemoteUser` `apiKey` security definition with `CognitoUser` `oauth2` security definition.  replace instances of `RemoteUser` with `CognitoUser`
* re-gen JS SDK code and docs
* enable JWT authentication using JWKS in trellis/etc/config.yml, update docker-compose.yml to pass env vars to make that work.