### PR TITLE
Authentication tests and touchups

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,14 @@ Trellis should be available at: http://localhost:8080 And there is a built-in Tr
 
 ## Sinopia Server Testing
 
-WIP.
+To run the full test suite, you'll need to supply some credentials for a real Amazon Cognito user that has access to Sinopia, because part of the integration testing is obtaining a real JWT to test Auth'n interactions with Trellis.  You'll also need to supply the user pool id info.  This info is specified via environment variables.
+
+In local development, you can do this by providing the env vars inline when invoking the tests, e.g.:
+```sh
+AUTH_TEST_USER='user@domain.edu' AUTH_TEST_PASS='1337secrets' AUTH_TEST_USER_POOL_ID='us-north-5_ABc1De234' AUTH_TEST_CLIENT_ID='blargh' npm run test
+```
+
+For the Circle CI tests, the env vars are already defined in the project contect.
 
 ### Sinopia Server Integration Tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,8 @@ services:
       context: .
       dockerfile: Dockerfile.trellis-ext-db
     environment:
-      TRELLIS_AUTH_JWT_ENABLED: 'true'
-      COGNITO_USER_POOL_ID: 'us-west-2_HUmNIdmhy'
-      AWS_COGNITO_REGION: 'us-west-2'
+      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-us-west-2_CGd9Wq136}
+      AWS_COGNITO_REGION: ${AWS_COGNITO_REGION:-us-west-2}
     ports:
       - 8080:8080
       - 8081:8081

--- a/sinopia_client/package-lock.json
+++ b/sinopia_client/package-lock.json
@@ -12,6 +12,17 @@
         "humanize-ms": "^1.2.1"
       }
     },
+    "amazon-cognito-identity-js": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-3.0.9.tgz",
+      "integrity": "sha512-RhgFLF81jmjjNIn8EbofPKeyarQ3aiGwBts1LtZDsmE8bHsRSom15xA23XTAfPBpboW+XZyFYbNc6vnOHnIAwg==",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.1",
+        "crypto-js": "^3.1.9-1",
+        "js-cookie": "^2.1.4"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -33,10 +44,41 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "aws-sdk": {
+      "version": "2.423.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.423.0.tgz",
+      "integrity": "sha512-BgsqrCMeJuE+gyWbqzDXvwzdEOyl5f9VIy0tgh78vqPI/09j9s4TKC9McMr6I4uTifVUpOxxultPS39PcTjQeA==",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+          "dev": true
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "brace-expansion": {
@@ -54,6 +96,17 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "chai": {
       "version": "4.2.0",
@@ -117,6 +170,12 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
+      "dev": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -159,6 +218,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "expect.js": {
       "version": "0.3.1",
@@ -250,6 +315,12 @@
         "ms": "^2.0.0"
       }
     },
+    "ieee754": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -264,6 +335,24 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
+    },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=",
+      "dev": true
     },
     "lodash": {
       "version": "4.17.11",
@@ -373,6 +462,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -394,10 +489,22 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
     "qs": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
       "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "readable-stream": {
       "version": "3.1.1",
@@ -418,6 +525,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
       "dev": true
     },
     "sinon": {
@@ -475,6 +588,16 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -489,10 +612,32 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     }
   }

--- a/sinopia_client/package.json
+++ b/sinopia_client/package.json
@@ -16,9 +16,12 @@
     "superagent": "^4.1.0"
   },
   "devDependencies": {
+    "amazon-cognito-identity-js": "^3.0.9",
+    "aws-sdk": "^2.423.0",
     "chai": "^4.2.0",
     "expect.js": "~0.3.1",
     "mocha": "^5.2.0",
+    "node-fetch": "^2.3.0",
     "sinon": "1.17.3"
   }
 }

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -86,7 +86,7 @@
       beforeEach(function() {
         let rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
         let baseRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server')
-        return instance.updateBase(baseRsrc).catch(function(err) { console.error(`Error setting up base container: ${err}`) })
+        return instance.updateBase(baseRsrc)
       });
 
       it('should call createGroup successfully', function() {
@@ -111,7 +111,7 @@
       beforeEach(function() {
         let rsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
         let baseRsrc = new SinopiaServer.SinopiaBasicContainer('', rsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Sinopia LDP Server')
-        return instance.updateBase(baseRsrc).catch(function(err) { console.error(`Error setting up base container: ${err}`) })
+        return instance.updateBase(baseRsrc)
       });
 
       describe('with non-RDF resources', function() {
@@ -119,7 +119,7 @@
         beforeEach(function() {
           let grpRsrcCtx = new SinopiaServer.SinopiaBasicContainerContext('http://www.w3.org/2000/01/rdf-schema#', 'http://www.w3.org/ns/ldp#')
           let groupRsrc = new SinopiaServer.SinopiaBasicContainer('', grpRsrcCtx, ['ldp:Container', 'ldp:BasicContainer'], 'Profiles Group')
-          return instance.createGroup('profiles', groupRsrc).catch(function(err) { console.error(`Error setting up profiles group: ${err}`) })
+          return instance.createGroup('profiles', groupRsrc)
         });
 
         it('should create a profile resource successfully', function() {
@@ -137,7 +137,6 @@
               expect(responseAndData.response.statusCode).to.equal(201)
               expect(responseAndData.response.headers.location).to.equal(`http://localhost:8080/repository/profiles/profile${rand_num}`)
             })
-            .catch(function(err) { console.error(`Error adding ${opts['slug']}: ${err}`) })
         });
       });
     });

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -381,6 +381,10 @@
   });
 
   describe('Authentication', function() {
+    // tests hit amazon and then trellis.  occasionally they run past the
+    // default 2 s timeout, so up it to 10 s (time specified in ms).
+    this.timeout(10000);
+
     // NOTE: if this test is failing for you locally, it may be because you're not supplying the login info required below.  none
     // of this is particularly sensitive (the test user should be a dummy user on a dev system, and user pool id and client id are public
     // info that a user can figure out by looking at our editor client source code).  regardless, good practice to not commit login

--- a/sinopia_client/test/api/LDPApi.spec.js
+++ b/sinopia_client/test/api/LDPApi.spec.js
@@ -405,6 +405,7 @@
     // to be populated with a useable token.  (if a beforeEach or test block returns a Promise, Mocha will wait
     // for that Promise to be settled before proceeding)
     beforeEach(function() {
+      // adapted from use case #4 here: https://github.com/aws-amplify/amplify-js/tree/01e660df246f0faf0bcb5b5ebf604597db3ef4aa/packages/amazon-cognito-identity-js#usage
       let cognitoUser = getCognitoUser(username, user_pool_id, client_id)
       return new Promise(function(resolve, reject) {
         cognitoUser.authenticateUser(getAuthenticationDetails(username, password), {

--- a/trellis/etc/config.yml
+++ b/trellis/etc/config.yml
@@ -76,7 +76,7 @@ baseUrl: ${TRELLIS_BASE_URL:-}
 hubUrl: ${TRELLIS_HUB_URL:-}
 
 auth:
-    adminUsers: ${TRELLIS_ADMIN_USERS:-[cmharlow]}
+    adminUsers: ${TRELLIS_ADMIN_USERS:-[]}
     webac:
         enabled: ${TRELLIS_AUTH_WEBAC_ENABLED:-true}
         cacheSize: ${TRELLIS_AUTH_WEBAC_CACHE_SIZE:-1000}

--- a/trellis/etc/config.yml
+++ b/trellis/etc/config.yml
@@ -82,10 +82,10 @@ auth:
         cacheSize: ${TRELLIS_AUTH_WEBAC_CACHE_SIZE:-1000}
         cacheExpireSeconds: ${TRELLIS_AUTH_WEBAC_CACHE_EXPIRE_SECONDS:-60}
     jwt:
-        enabled: ${TRELLIS_AUTH_JWT_ENABLED:-false}
+        enabled: ${TRELLIS_AUTH_JWT_ENABLED:-true}
         jwks: https://cognito-idp.${AWS_COGNITO_REGION}.amazonaws.com/${COGNITO_USER_POOL_ID}/.well-known/jwks.json
     basic:
-        enabled: ${TRELLIS_AUTH_BASIC_ENABLED:-true}
+        enabled: ${TRELLIS_AUTH_BASIC_ENABLED:-false}
         usersFile: ${TRELLIS_AUTH_BASIC_USERS_FILE:-/opt/trellis/etc/users.auth}
 
 cors:

--- a/trellis/etc/users.auth
+++ b/trellis/etc/users.auth
@@ -9,6 +9,7 @@
 # For example:
 # someuser : secret : http://example.org/someuser/
 
-cmharlow : S3cr3t! : http://sinopia.io/users/cmharlow
-
-suntzu : S6ntz6? : http://sinopia.io/users/suntzu
+# FOR TESTING ONLY!  don't use this in production.
+#cmharlow : S3cr3t! : http://sinopia.io/users/cmharlow
+#
+#suntzu : S6ntz6? : http://sinopia.io/users/suntzu


### PR DESCRIPTION
~build is failing because the ld4p/trellis-ext-db docker image with proper JWT configuration isn't available.  i have that locally, will get that built/tagged/pushed to dockerhub tomorrow.~
That was a red herring.  The issue was that the two Cognito-related environment variables Trellis needs to have the config point to the right JWKS were hardcoded to stale values (another env var was no longer needed since it specified what is now the default in config.yml, enabling JWT auth).  I pushed a follow-on commit that allows the environment running docker-compose to specify overriding values for the Cognito environment variables (and I fixed the values for both the docker-compose.yml defaults and the Circle-specified overriding values; if things fall out of date, only the circle values need fixing to get the build to pass again).

Of course, the latest ld4p/trellis-ext-db still needs pushing to dockerhub for other consumers (when using this repo's docker-compose.yml as its Circle build does, the image is re-built as needed from local Dockerfile, as specified by the `build` section of docker-compose.yml).

closes #73 