### PR TITLE
Adds allowHeaders to cors configuration

### DIFF
--- a/trellis/etc/config.yml
+++ b/trellis/etc/config.yml
@@ -93,6 +93,15 @@ cors:
     allowOrigin:
         - "*"
     maxAge: ${TRELLIS_CORS_MAX_AGE:-180}
+    allowHeaders:
+        - "Content-Type"
+        - "Authorization"
+        - "Link"
+        - "Accept"
+        - "Accept-DateTime"
+        - "Prefer"
+        - "Slug"
+        - "Origin"
 
 cache:
     maxAge: ${TRELLIS_CACHE_MAX_AGE:-86400}


### PR DESCRIPTION
Include Authorization as an allowed header (as well as the  default header options) in order to allow the editor and other applications to talk to the server from a different origin, as well as passing in the JWT as the auth header.