### PR TITLE
Allow content-type header on update resource requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ See the Specification-driven API documentation here: https://ld4p.github.io/sino
 ### Installing swagger-codegen
 
 [swagger-codegen-2.4.0](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.0) is the latest version of swagger-codegen that supports the Javascript language and parses this project's Swagger spec without error.  You can obtain the JAR file you need from:
-* https://mvnrepository.com/artifact/io.swagger/swagger-codegen/2.4.0 (Maven Repository info page)
-* http://central.maven.org/maven2/io/swagger/swagger-codegen/2.4.0/swagger-codegen-2.4.0.jar (direct download link)
+* https://mvnrepository.com/artifact/io.swagger/swagger-codegen-cli/2.4.0 (Maven Repository info page)
+* http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.0/swagger-codegen-cli-2.4.0.jar (direct download link)
 
 The following commands assume the swagger-codegen JAR file is in the same directory as the swagger.yaml
 file (and where applicable, the output directory for the generated client code, i.e. you downloaded the
@@ -122,7 +122,7 @@ java -jar swagger-codegen-cli-2.4.0.jar validate -i swagger.yaml
 #### (Re-)Generating the Sinopia Server Javascript Client with swagger-codegen CLI
 
 ```sh
-$ java -jar swagger-codegen-2.4.0.jar generate -i swagger.yaml -l javascript --additional-properties usePromises=true -o sinopia_client/
+$ java -jar swagger-codegen-cli-2.4.0.jar generate -i swagger.yaml -l javascript --additional-properties usePromises=true -o sinopia_client/
 ```
 
 You'll want to make sure the couple of hand edits to the generated client code aren't blown away when you commit the updates (yes, gross, sorry).

--- a/sinopia_client/docs/LDPApi.md
+++ b/sinopia_client/docs/LDPApi.md
@@ -1161,7 +1161,7 @@ var resourceID = "resourceID_example"; // String | The UUID for the resource def
 var resource = new SinopiaServer.Resource(); // Resource | Resource metadata to replace existing description of the given group.
 
 var opts = { 
-  'contentType': "contentType_example" // String | Content-Type of Group metadata, with preference for JSON-LD.
+  'contentType': "contentType_example" // String | Content-Type for the resource, with preference for JSON-LD.
 };
 apiInstance.updateResource(groupID, resourceID, resource, opts).then(function() {
   console.log('API called successfully.');
@@ -1178,7 +1178,7 @@ Name | Type | Description  | Notes
  **groupID** | **String**| The group who is defining it&#39;s own resources or graph within Sinopia. | 
  **resourceID** | **String**| The UUID for the resource defined and managed within Sinopia. | 
  **resource** | [**Resource**](Resource.md)| Resource metadata to replace existing description of the given group. | 
- **contentType** | **String**| Content-Type of Group metadata, with preference for JSON-LD. | [optional] 
+ **contentType** | **String**| Content-Type for the resource, with preference for JSON-LD. | [optional] 
 
 ### Return type
 
@@ -1190,7 +1190,7 @@ null (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: application/ld+json
+ - **Content-Type**: Not defined
  - **Accept**: application/ld+json
 
 <a name="updateUser"></a>

--- a/sinopia_client/src/api/LDPApi.js
+++ b/sinopia_client/src/api/LDPApi.js
@@ -37,7 +37,7 @@
    */
 
   /**
-   * Constructs a new LDPApi. 
+   * Constructs a new LDPApi.
    * @alias module:api/LDPApi
    * @class
    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
@@ -1328,7 +1328,7 @@
      * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
      * @param {module:model/Resource} resource Resource metadata to replace existing description of the given group.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     this.updateResourceWithHttpInfo = function(groupID, resourceID, resource, opts) {
@@ -1366,7 +1366,7 @@
       };
 
       var authNames = ['CognitoUser'];
-      var contentTypes = ['application/ld+json'];
+      var contentTypes = [];
       var accepts = ['application/ld+json'];
       var returnType = null;
 
@@ -1384,7 +1384,7 @@
      * @param {String} resourceID The UUID for the resource defined and managed within Sinopia.
      * @param {module:model/Resource} resource Resource metadata to replace existing description of the given group.
      * @param {Object} opts Optional parameters
-     * @param {String} opts.contentType Content-Type of Group metadata, with preference for JSON-LD.
+     * @param {String} opts.contentType Content-Type for the resource, with preference for JSON-LD.
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
     this.updateResource = function(groupID, resourceID, resource, opts) {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -509,6 +509,7 @@ paths:
         - LDP
       security:
         - CognitoUser: []
+      consumes: [] # client must specify content type, can be json or ld+json, see params
       parameters:
         - name: groupID
           description: The group who is defining it's own resources or graph within Sinopia.
@@ -528,7 +529,7 @@ paths:
             $ref: '#/definitions/Resource'
         - name: Content-Type
           in: header
-          description: Content-Type of Group metadata, with preference for JSON-LD.
+          description: Content-Type for the resource, with preference for JSON-LD.
           required: false
           type: string
       responses:


### PR DESCRIPTION
Fixes #94

Also, regenerate client code after making Swagger spec changes.

Note that I did not `regenerate test stubs` as covered in the README. I am not sure if I should or not. Tagging @jmartin-sul for advice