### PR TITLE
Automatically build and push trellis-ext-db image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,21 @@ jobs:
             dockerize -wait http://localhost:8081/healthcheck -timeout 1m
             cd sinopia_client
             npm run test
+  register_image:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build & push docker image
+          # NOTE: the env variables holding docker credentials are stored in the CircleCI dashboard
+          command: |
+            git diff --name-only HEAD^ | grep -E '(Dockerfile|trellis)' || exit 0
+            docker build -f Dockerfile.trellis-ext-db -t ld4p/trellis-ext-db:latest .
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            docker push ld4p/trellis-ext-db:latest
 
 workflows:
   version: 2
@@ -42,3 +57,10 @@ workflows:
       - test:
           requires:
             - dependencies
+      - register_image:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master

--- a/Dockerfile.trellis-ext-db
+++ b/Dockerfile.trellis-ext-db
@@ -5,4 +5,4 @@ LABEL maintainer="SUL Infrastructure Team <dlss-infrastructure-team@lists.stanfo
 
 COPY trellis/etc/ /opt/trellis/etc/
 
-RUN ls -lah /opt/trellis/etc/
+RUN ls -lha /opt/trellis/etc/


### PR DESCRIPTION
But only 1) on changes to the `master` branch, and 2) when the changed files include the Dockerfile or any files under the `trellis` directory. This gives us automatic image updates without triggering unnecessary builds/pushes—i.e., if changes are made to the sinopia_client or the README, for instance, which do not require a new image.

Includes a token change to the `Dockerfile` to test the new CircleCI configuration once merged to `master`.