### PR TITLE
Use docker executor in CI to build and push images automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,14 @@ jobs:
       - run:
           name: bring up trellis-ext-db, wait for it to start, run sinopia client integration tests
           command: |
-            docker-compose up -d
-            dockerize -wait http://localhost:8081/healthcheck -timeout 1m
+            docker-compose up -d platform
             cd sinopia_client
+            dockerize -wait http://localhost:8081/healthcheck -timeout 1m
             npm run test
   register_image:
-    <<: *defaults
+    working_directory: ~/sinopia_server
+    docker:
+      - image: circleci/node:10.15.3
     steps:
       - checkout
       - setup_remote_docker
@@ -44,7 +46,7 @@ jobs:
           name: Build & push docker image
           # NOTE: the env variables holding docker credentials are stored in the CircleCI dashboard
           command: |
-            git diff --name-only HEAD^ | grep -E '(Dockerfile|trellis)' || exit 0
+            git diff --name-only origin/HEAD | grep -E '(Dockerfile|trellis)' || exit 0
             docker build -f Dockerfile.trellis-ext-db -t ld4p/trellis-ext-db:latest .
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker push ld4p/trellis-ext-db:latest

--- a/README.md
+++ b/README.md
@@ -147,9 +147,12 @@ This requires publishing rights on https://www.npmjs.com/package/sinopia_server
 
 ## Rebuilding our (Sinopia-specific) trellis-ext-db image and pushing to Docker Hub
 
+The CircleCI build is configured to perform these steps automatically on any successful build on the `master` branch that touches files that should trigger a rebuild/repush. If you **do** need to manually build and push an image, you can do this via:
+
+
 ```shell
 $ docker build -f Dockerfile.trellis-ext-db -t ld4p/trellis-ext-db .
 $ docker push ld4p/trellis-ext-db  # assumes user is logged into docker hub account via 'docker login' command
 ```
 
-This requires push access to the ld4p Docker Hub organization.
+**NOTE**: The `docker push` action requires push access to the [ld4p Docker Hub organization](https://hub.docker.com/u/ld4p).


### PR DESCRIPTION
And only do this if there have been changes to the Dockerfile or within the
`trellis` directory. To test this, make a trivial change to the Dockerfile.

Fixes #105 