### PR TITLE
Typo in workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,6 @@ workflows:
             branches:
               only:
                 - master
-      - udpate_ecs:
+      - update_ecs:
           requires:
             - register_image


### PR DESCRIPTION
Fixes the typo in the workflow that is causing the master build to fail.