### PR TITLE
add a console log appender for request logging

### DIFF
--- a/trellis/etc/config.yml
+++ b/trellis/etc/config.yml
@@ -7,6 +7,9 @@ server:
       port: ${TRELLIS_ADMIN_HTTP_PORT:-8081}
   requestLog:
     appenders:
+      - type: console
+        target: stdout
+        threshold: ${TRELLIS_CONSOLE_LOGGING_THRESHOLD:-INFO}
       - type: file
         currentLogFilename: /opt/trellis/log/access.log
         archive: true


### PR DESCRIPTION
this makes it so that all logging goes to console, in addition to files, which makes the log output readily available to cloudwatch.

connects to #51